### PR TITLE
feat(transloco): support nested array of scopes

### DIFF
--- a/libs/transloco/src/lib/helpers.ts
+++ b/libs/transloco/src/lib/helpers.ts
@@ -1,4 +1,4 @@
-import { ProviderScope, Translation } from './types';
+import { NestedArray, ProviderScope, Translation } from './types';
 import { flatten as _flatten, unflatten as _unflatten } from 'flat';
 
 export function getValue<T>(obj: T, path: keyof T) {
@@ -129,4 +129,10 @@ export function unflatten(obj: Translation): Translation {
 
 export function flatten(obj: Translation): Translation {
   return _flatten(obj, { safe: true });
+}
+
+export function flattenArray<T>(arr: NestedArray<T>): T[] {
+  // not using "Infinity" to avoid call stack issues if someone passes an array that references itself
+  // "100 as 1" is used to trick TS to not attempt to resolve that level of nesting
+  return arr.flat(100 as 1) as T[];
 }

--- a/libs/transloco/src/lib/scope-resolver.ts
+++ b/libs/transloco/src/lib/scope-resolver.ts
@@ -1,10 +1,10 @@
-import { TranslocoScope, ProviderScope, MaybeArray } from './types';
+import { TranslocoScope, ProviderScope } from './types';
 import { TranslocoService } from './transloco.service';
 import { isScopeObject, toCamelCase } from './helpers';
 
 type ScopeResolverParams = {
   inline: string | undefined;
-  provider: MaybeArray<TranslocoScope>;
+  provider: TranslocoScope;
 };
 
 export class ScopeResolver {

--- a/libs/transloco/src/lib/transloco.directive.ts
+++ b/libs/transloco/src/lib/transloco.directive.ts
@@ -30,6 +30,7 @@ import {
 } from './shared';
 import { LangResolver } from './lang-resolver';
 import { ScopeResolver } from './scope-resolver';
+import { flattenArray } from './helpers';
 
 type TranslateFn = (key: string, params?: HashMap) => any;
 interface ViewContext {
@@ -107,7 +108,7 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
 
           return Array.isArray(this.providerScope)
             ? forkJoin(
-                (<TranslocoScope[]>this.providerScope).map((providerScope) =>
+                flattenArray(this.providerScope).map((providerScope) =>
                   this.resolveScope(lang, providerScope)
                 )
               )

--- a/libs/transloco/src/lib/transloco.pipe.ts
+++ b/libs/transloco/src/lib/transloco.pipe.ts
@@ -19,6 +19,7 @@ import {
 } from './shared';
 import { LangResolver } from './lang-resolver';
 import { ScopeResolver } from './scope-resolver';
+import { flattenArray } from './helpers';
 
 @Pipe({
   name: 'transloco',
@@ -79,7 +80,7 @@ export class TranslocoPipe implements PipeTransform, OnDestroy {
 
           return Array.isArray(this.providerScope)
             ? forkJoin(
-                (<TranslocoScope[]>this.providerScope).map((providerScope) =>
+                flattenArray(this.providerScope).map((providerScope) =>
                   this.resolveScope(lang, providerScope)
                 )
               )

--- a/libs/transloco/src/lib/types.ts
+++ b/libs/transloco/src/lib/types.ts
@@ -44,7 +44,8 @@ export interface ProviderScope {
   loader?: InlineLoader;
   alias?: string;
 }
-export type MaybeArray<T> = T | T[];
+export type NestedArray<T> = Array<T> | Array<NestedArray<T>>;
+export type MaybeArray<T> = T | NestedArray<T>;
 export type TranslocoScope = ProviderScope | string | undefined;
 export type InlineLoader = HashMap<() => Promise<Translation>>;
 export interface LoadOptions {

--- a/libs/transloco/tsconfig.lib.json
+++ b/libs/transloco/tsconfig.lib.json
@@ -7,7 +7,7 @@
     "declarationMap": true,
     "inlineSources": true,
     "types": [],
-    "lib": ["dom", "es2018"]
+    "lib": ["dom", "es2019"]
   },
   "exclude": ["src/test-setup.ts", "**/*.spec.ts"],
   "include": ["**/*.ts"]

--- a/nx.json
+++ b/nx.json
@@ -14,12 +14,7 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": [
-          "build",
-          "lint",
-          "test",
-          "e2e"
-        ],
+        "cacheableOperations": ["build", "lint", "test", "e2e"],
         "parallel": 1
       }
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Right now transloco is able to resolve only 1-level array of scopes. This works fine with straightforward approach when using `{ provide: TRANSLOCO_SCOPE, useValue: scope, multi: true }`. However, it might be needed to pass an array of scopes within single provider.


## What is the new behavior?
This change allows to use the following syntax
```
{ 
  provide: TRANSLOCO_SCOPE,
  useValue: ['scope1', 'scope2']
  multi: true
}
```

In my scenario there's a big amount of scopes that we're using. They're provided either as component or module providers. And there's a limitation related to Angular's injection hierarchy: it resolves ElementInjectors before ModuleInjectors and if TRANSLOCO_SCOPE is provided on the ElementInjector level, it won't grab module injectors at all. To overcome this I want to grab all parent scopes and provide them explicitly

```
export function provideLanguageScopes(
  scope: LanguageScope,
  ...otherScopes: LanguageScope[]
): Provider {
  const scopeSet = new Set(otherScopes.concat(scope));
  return {
    provide: TRANSLOCO_SCOPE,
    useFactory: (parentScopes: LanguageScope[] | null) => {
      parentScopes && parentScopes.flat(Infinity).forEach(p => scopeSet.add(p));
      return [...scopeSet.values()];
    },
    multi: true,
    deps: [[new SkipSelf(), new Optional(), TRANSLOCO_SCOPE]],
  };
}
```

This approach requires transloco to be able to work with nested arrays of scopes. This PR does not introduce any changes to existing behavior, only enhances it so that it is possible to provide arrays under `TRANSLOCO_SCOPE`

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```
Setting `yes` as there's a change to `MaybeArray` interface, that might not be compatible with all implementations
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
