### PR TITLE
feat(transloco): 🎸 allow to omit available languages

### DIFF
--- a/docs/docs/getting-started/config-options.mdx
+++ b/docs/docs/getting-started/config-options.mdx
@@ -60,6 +60,8 @@ translocoConfig({
   availableLangs: ['en', 'es']
 })
 ```
+When the active language is not included in the `availableLangs`, the translations of this language will not be returned.
+You can omit this option or set it to `null`, in this case the translations will be returned for any language, if available.
 
 ### `missingHandler.allowEmpty`
 Whether to allow empty values: (defaults to `false`)

--- a/libs/transloco/src/lib/tests/service/translate.spec.ts
+++ b/libs/transloco/src/lib/tests/service/translate.spec.ts
@@ -79,4 +79,16 @@ describe('translate', () => {
       'Admin Lazy spanish'
     );
   }));
+  
+  it('should return the translation when availableLangs is skipped', fakeAsync(() => {
+    service.setAvailableLangs(undefined);
+    loadLang(service);
+    expect(service.translate('home')).toEqual(mockLangs['en'].home);
+  }));
+  
+  it('should return the translation when availableLangs is set to null', fakeAsync(() => {
+    service.setAvailableLangs(null);
+    loadLang(service);
+    expect(service.translate('home')).toEqual(mockLangs['en'].home);
+  }));
 });

--- a/libs/transloco/src/lib/transloco.config.ts
+++ b/libs/transloco/src/lib/transloco.config.ts
@@ -8,7 +8,7 @@ export interface TranslocoConfig {
   prodMode: boolean;
   fallbackLang?: string | string[];
   failedRetries: number;
-  availableLangs: AvailableLangs;
+  availableLangs?: AvailableLangs;
   flatten: {
     aot: boolean;
   };

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -102,7 +102,7 @@ export class TranslocoService implements OnDestroy {
   private cache = new Map<string, Observable<Translation>>();
   private firstFallbackLang: string | undefined;
   private defaultLang = '';
-  private availableLangs: AvailableLangs = [];
+  private availableLangs?: AvailableLangs;
   private isResolvedMissingOnce = false;
   private lang: BehaviorSubject<string>;
   private failedLangs = new Set<string>();
@@ -129,7 +129,7 @@ export class TranslocoService implements OnDestroy {
     service = this;
     this.config = structuredClone(userConfig);
 
-    this.setAvailableLangs(this.config.availableLangs || []);
+    this.setAvailableLangs(this.config.availableLangs);
     this.setFallbackLangForMissingTranslation(this.config);
     this.setDefaultLang(this.config.defaultLang);
     this.lang = new BehaviorSubject<string>(this.getDefaultLang());
@@ -169,7 +169,7 @@ export class TranslocoService implements OnDestroy {
     return this;
   }
 
-  setAvailableLangs(langs: AvailableLangs) {
+  setAvailableLangs(langs: AvailableLangs | undefined) {
     this.availableLangs = langs;
   }
 
@@ -181,7 +181,7 @@ export class TranslocoService implements OnDestroy {
    * depending on how the available languages are set in your module.
    */
   getAvailableLangs() {
-    return this.availableLangs;
+    return this.availableLangs ?? [];
   }
 
   load(path: string, options: LoadOptions = {}): Observable<Translation> {
@@ -626,7 +626,11 @@ export class TranslocoService implements OnDestroy {
    * @internal
    */
   _isLangScoped(lang: string) {
-    return this.getAvailableLangsIds().indexOf(lang) === -1;
+    const availableLangsIds = this.getAvailableLangsIds();
+    if (!availableLangsIds) {
+      return true;
+    }
+    return availableLangsIds.indexOf(lang) === -1;
   }
 
   /**
@@ -636,7 +640,11 @@ export class TranslocoService implements OnDestroy {
    * False if the given string is not an available language.
    */
   isLang(lang: string): boolean {
-    return this.getAvailableLangsIds().indexOf(lang) !== -1;
+    const availableLangsIds = this.getAvailableLangsIds();
+    if (!availableLangsIds) {
+      return true;
+    }
+    return availableLangsIds.indexOf(lang) !== -1;
   }
 
   /**
@@ -701,8 +709,12 @@ export class TranslocoService implements OnDestroy {
     return size(this.getTranslation(lang));
   }
 
-  private getAvailableLangsIds(): string[] {
-    const first = this.getAvailableLangs()[0];
+  private getAvailableLangsIds(): string[] | null {
+    const first = this.getAvailableLangs()?.[0];
+    
+    if (isNil(first)) {
+      return null;
+    }
 
     if (isString(first)) {
       return this.getAvailableLangs() as string[];

--- a/libs/transloco/src/lib/types.ts
+++ b/libs/transloco/src/lib/types.ts
@@ -30,7 +30,7 @@ export interface LangDefinition {
   id: string;
   label: string;
 }
-export type AvailableLangs = string[] | LangDefinition[];
+export type AvailableLangs = string[] | LangDefinition[] | null;
 export interface SetTranslationOptions {
   merge?: boolean;
   emitChange?: boolean;


### PR DESCRIPTION
Currently the available languages need to be set, otherwise the translated values won't be returned. With this change the translation will also work when omitting the availableLangs config, or setting it to null.

✅ Closes: #653

<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently it is not allow to omit `availableLangs` by typings. When setting it to empty array, translation will never work, because there is a check whether the current language is available. There is no way to skip this check.

Issue Number: #653

## What is the new behavior?

The check whether the current language is in the list of available languages can be skipped by omitting `availableLangs` in the config or setting it to `null`. This allows translation without the need of maintaining `availableLangs`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
