### PR TITLE
docs: Link to date format options documentation

### DIFF
--- a/docs/docs/plugins/locale.mdx
+++ b/docs/docs/plugins/locale.mdx
@@ -362,6 +362,8 @@ Note the format option of the global, locale's format and the one's being passed
 - `timeStyle` - The time formatting style.
 - `timeZone` - The time zone to use. The only value implementations must recognize is "UTC"; the default is the runtime's default time zone. Implementations may also recognize the time zone names of the [IANA](https://www.iana.org/time-zones) time zone database, such as "Asia/Shanghai", "Asia/Kolkata", "America/New_York".
 
+By default those options are passed to the native `Intl.DateTimeFormat`, full documentation for the options you can find [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options)
+
 ## Service API
 
 - `localeChanges$` - Observable of the active locale.


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
There's no information about available values for date options nor where to find it. [Here](https://ngneat.github.io/transloco/docs/plugins/locale#date-format-options)

## What is the new behavior?
There is an information where to find available values for the date options.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
