### PR TITLE
docs: links to documentation now point to jsverse.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ It exposes a rich API to manage translations efficiently and cleanly. It provide
 [![spectator](https://img.shields.io/badge/tested%20with-spectator-2196F3.svg?style=flat-square)](https://github.com/ngneat/spectator)
 [![Join the chat at https://gitter.im/ngneat-transloco](https://badges.gitter.im/gitterHQ/gitter.svg)](https://gitter.im/ngneat-transloco/lobby?source=orgpage)
 
-- 🤓 &nbsp;Learn about it on the [docs site](https://ngneat.github.io/transloco/)
+- 🤓 &nbsp;Learn about it on the [docs site](https://jsverse.github.io/transloco/)
 - 🎥 &nbsp;Watch our instructional [video guides](https://www.youtube.com/watch?v=MYkYcafJdGw&list=PLTuTW7EgL6ouXk5BqE4zWdDJkAuC4HTWi)
 - 🚀 &nbsp;See it in action on [CodeSandbox](https://codesandbox.io/s/ngneat-transloco-kn52hs)
-- 😎 &nbsp;Use [schematics](https://ngneat.github.io/transloco/docs/schematics)
-- 👉 &nbsp;Checkout the [live application](https://ngneat.github.io/transloco/live-app)
-- 📖 &nbsp;Read the blog [posts](https://ngneat.github.io/transloco/docs/blog-posts)
+- 😎 &nbsp;Use [schematics](https://jsverse.github.io/transloco/docs/schematics)
+- 👉 &nbsp;Checkout the [live application](https://jsverse.github.io/transloco/live-app)
+- 📖 &nbsp;Read the blog [posts](https://jsverse.github.io/transloco/docs/blog-posts)
 - 🍄 &nbsp;Join Transloco's [Gitter](https://gitter.im/ngneat-transloco/lobby?source=orgpage) room
-- ❓ &nbsp;Find answers in our [FAQ](https://ngneat.github.io/transloco/docs/faq) section
+- ❓ &nbsp;Find answers in our [FAQ](https://jsverse.github.io/transloco/docs/faq) section
 
 ## Contributors ✨
 


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The repo was transferred, meaning the links to the documentation have also changed. Currently it is not possible to access the documentation without manually updating the URL.

Issue Number: N/A

## What is the new behavior?

The links in the documentation now point to jsverse.github.io/ instead of ngneat.github.io/

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Google (and likely other search engines, too) has not yet picked up on this change. Accessing the documentation at the moment is quite a hassle.