### PR TITLE
fix(transloco): 🐛 prioritize finding culture languages

### DIFF
--- a/libs/transloco/src/lib/browser-lang.ts
+++ b/libs/transloco/src/lib/browser-lang.ts
@@ -30,5 +30,9 @@ export function getBrowserCultureLang(): string {
 
   const navigator = window.navigator;
 
-  return navigator.languages?.[0] ?? navigator.language;
+  return (
+    navigator.languages.find((lang) =>
+      ['-', '_'].some((c) => lang.includes(c)),
+    ) ?? navigator.language
+  );
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #472

## What is the new behavior?

When looking for the language in `navigator.languages`, the first culture language (i.e. `en-US` or `en_US` instead of `en`) is selected.

This solves the case where the list is `['en', 'en-US', 'fr', 'fr-FR']` while still taking the order into account.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
