### PR TITLE
feat(transloco): 🎸 add option to not change the casing of the provided scope

### DIFF
--- a/docs/docs/getting-started/config-options.mdx
+++ b/docs/docs/getting-started/config-options.mdx
@@ -133,3 +133,14 @@ translocoConfig({
   interpolation: ['<<<', '>>>'],
 });
 ```
+
+### `scopes.keepCasing`
+This will make sure that the casing of the provided scope name is not altered, given that no alias has been set otherwise this setting will be ignored.
+
+```ts
+translocoConfig({
+  scopes: {
+    keepCasing: false
+  }
+})
+```

--- a/docs/docs/lazy-load/scope-configuration.mdx
+++ b/docs/docs/lazy-load/scope-configuration.mdx
@@ -139,8 +139,9 @@ Now we can access each one of the `todos` keys by using the `todos` namespace:
 ```
 
 ## Scope's namespace
+By default, the namespace will be the `scope`'s name camel-cased. you can keep the original casing by providing the [`scope.keepCasing`](../getting-started/config-options#scopeskeepcasing) config option.
 
-By default, the namespace will be the `scope` name (camel cased), but we can override it by providing custom `alias` name in the module/component `scope` provider:
+You can also provide a custom scope namespace by specifying an `alias` name in the module/component `scope` provider:
 
 ```ts
 provideTranslocoScope({ scope: 'todos', alias: 'customName' });

--- a/libs/transloco/src/lib/scope-resolver.ts
+++ b/libs/transloco/src/lib/scope-resolver.ts
@@ -19,7 +19,12 @@ export class ScopeResolver {
 
     if (provider) {
       if (isScopeObject(provider)) {
-        const { scope, alias = toCamelCase(scope) } = provider as ProviderScope;
+        const {
+          scope,
+          alias = this.service.config.scopes.keepCasing
+            ? scope
+            : toCamelCase(scope),
+        } = provider as ProviderScope;
         this.service._setScopeAlias(scope, alias);
 
         return scope;

--- a/libs/transloco/src/lib/tests/scope-resolver.spec.ts
+++ b/libs/transloco/src/lib/tests/scope-resolver.spec.ts
@@ -8,6 +8,11 @@ describe('ScopeResolver', () => {
     spy = jasmine.createSpy('setScopeAlias');
     resolver = new ScopeResolver({
       _setScopeAlias: spy,
+      config: {
+        scopes: {
+          keepCasing: false,
+        },
+      },
     } as any);
   });
 
@@ -81,5 +86,21 @@ describe('ScopeResolver', () => {
       'nested/scopes/admin-page',
       'nestedScopesAdminPage',
     );
+  });
+
+  it('should keep the original scope name', () => {
+    resolver = new ScopeResolver({
+      _setScopeAlias: spy,
+      config: { scopes: { keepCasing: true } },
+    } as any);
+
+    expect(
+      resolver.resolve({
+        inline: undefined,
+        provider: { scope: 'AdMiN-pAgE' },
+      }),
+    ).toEqual('AdMiN-pAgE');
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('AdMiN-pAgE', 'AdMiN-pAgE');
   });
 });

--- a/libs/transloco/src/lib/tests/service/setTranslation.spec.ts
+++ b/libs/transloco/src/lib/tests/service/setTranslation.spec.ts
@@ -102,5 +102,16 @@ describe('setTranslation', () => {
       };
       expect(setTranslationsSpy).toHaveBeenCalledWith('en', merged);
     });
+
+    it("should not change scope's name given scope.keepCasing is set to true", () => {
+      service.config.scopes.keepCasing = true;
+      lang = 'LAZY-page/en';
+      service.setTranslation(translation, lang);
+      const merged = {
+        ...flatten(mockLangs.en),
+        ...flatten({ 'LAZY-page': { ...translation } }),
+      };
+      expect(setTranslationsSpy).toHaveBeenCalledWith('en', merged);
+    });
   });
 });

--- a/libs/transloco/src/lib/transloco.config.ts
+++ b/libs/transloco/src/lib/transloco.config.ts
@@ -18,6 +18,9 @@ export interface TranslocoConfig {
     allowEmpty: boolean;
   };
   interpolation: [string, string];
+  scopes: {
+    keepCasing?: boolean;
+  };
 }
 
 export const TRANSLOCO_CONFIG = new InjectionToken<TranslocoConfig>(
@@ -44,6 +47,9 @@ export const defaultConfig: TranslocoConfig = {
     aot: false,
   },
   interpolation: ['{{', '}}'],
+  scopes: {
+    keepCasing: false,
+  },
 };
 
 type DeepPartial<T> =
@@ -68,6 +74,10 @@ export function translocoConfig(
     flatten: {
       ...defaultConfig.flatten,
       ...config.flatten,
+    },
+    scopes: {
+      ...defaultConfig.scopes,
+      ...config.scopes,
     },
   };
 }

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -789,8 +789,10 @@ export class TranslocoService implements OnDestroy {
   }
 
   private getMappedScope(scope: string): string {
-    const { scopeMapping = {} } = this.config;
-    return scopeMapping[scope] || toCamelCase(scope);
+    const { scopeMapping = {}, scopes = { keepCasing: false } } = this.config;
+    return (
+      scopeMapping[scope] || (scopes.keepCasing ? scope : toCamelCase(scope))
+    );
   }
 
   /**


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently the `scope` is being altered by the `toCamelCase` helper method. This creates the issue that if you provide a `scope` where you would like to have the first character not to be changed OR just the casing in general you can only do this by providing an `alias`.

e.g `{ scope: 'FOOBAR', alias: 'FOOBAR' }`

Issue Number: N/A

## What is the new behavior?

This feature enabled the possibility to only provide the scope and the casing of it will not be altered, so you can just use this: `{ scope: 'FOOBAR' }` or `{ scope: 'F-OO-BaR' } --> will be transformed to `{ scope: 'FOOBaR' }` 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
