### PR TITLE
refactor(transloco): tree-shake injection token names in production

### DIFF
--- a/libs/transloco/src/lib/transloco-fallback-strategy.ts
+++ b/libs/transloco/src/lib/transloco-fallback-strategy.ts
@@ -3,7 +3,11 @@ import { Inject, Injectable, InjectionToken } from '@angular/core';
 import { TRANSLOCO_CONFIG, TranslocoConfig } from './transloco.config';
 
 export const TRANSLOCO_FALLBACK_STRATEGY =
-  new InjectionToken<TranslocoFallbackStrategy>('TRANSLOCO_FALLBACK_STRATEGY');
+  new InjectionToken<TranslocoFallbackStrategy>(
+    typeof ngDevMode !== 'undefined' && ngDevMode
+      ? 'TRANSLOCO_FALLBACK_STRATEGY'
+      : '',
+  );
 
 export interface TranslocoFallbackStrategy {
   getNextLangs(failedLang: string): string[];

--- a/libs/transloco/src/lib/transloco-lang.ts
+++ b/libs/transloco/src/lib/transloco-lang.ts
@@ -1,3 +1,5 @@
 import { InjectionToken } from '@angular/core';
 
-export const TRANSLOCO_LANG = new InjectionToken<string>('TRANSLOCO_LANG');
+export const TRANSLOCO_LANG = new InjectionToken<string>(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_LANG' : '',
+);

--- a/libs/transloco/src/lib/transloco-loading-template.ts
+++ b/libs/transloco/src/lib/transloco-loading-template.ts
@@ -3,5 +3,7 @@ import { InjectionToken } from '@angular/core';
 import { Content } from './template-handler';
 
 export const TRANSLOCO_LOADING_TEMPLATE = new InjectionToken<Content>(
-  'TRANSLOCO_LOADING_TEMPLATE',
+  typeof ngDevMode !== 'undefined' && ngDevMode
+    ? 'TRANSLOCO_LOADING_TEMPLATE'
+    : '',
 );

--- a/libs/transloco/src/lib/transloco-missing-handler.ts
+++ b/libs/transloco/src/lib/transloco-missing-handler.ts
@@ -4,7 +4,11 @@ import { TranslocoConfig } from './transloco.config';
 import { HashMap } from './types';
 
 export const TRANSLOCO_MISSING_HANDLER =
-  new InjectionToken<TranslocoMissingHandlerData>('TRANSLOCO_MISSING_HANDLER');
+  new InjectionToken<TranslocoMissingHandlerData>(
+    typeof ngDevMode !== 'undefined' && ngDevMode
+      ? 'TRANSLOCO_MISSING_HANDLER'
+      : '',
+  );
 
 export interface TranslocoMissingHandlerData extends TranslocoConfig {
   activeLang: string;

--- a/libs/transloco/src/lib/transloco-scope.ts
+++ b/libs/transloco/src/lib/transloco-scope.ts
@@ -3,5 +3,5 @@ import { InjectionToken } from '@angular/core';
 import { TranslocoScope } from './types';
 
 export const TRANSLOCO_SCOPE = new InjectionToken<TranslocoScope>(
-  'TRANSLOCO_SCOPE',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_SCOPE' : '',
 );

--- a/libs/transloco/src/lib/transloco.config.ts
+++ b/libs/transloco/src/lib/transloco.config.ts
@@ -24,7 +24,7 @@ export interface TranslocoConfig {
 }
 
 export const TRANSLOCO_CONFIG = new InjectionToken<TranslocoConfig>(
-  'TRANSLOCO_CONFIG',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_CONFIG' : '',
   {
     providedIn: 'root',
     factory: () => defaultConfig,

--- a/libs/transloco/src/lib/transloco.interceptor.ts
+++ b/libs/transloco/src/lib/transloco.interceptor.ts
@@ -3,7 +3,7 @@ import { InjectionToken, Injectable } from '@angular/core';
 import { Translation } from './types';
 
 export const TRANSLOCO_INTERCEPTOR = new InjectionToken<TranslocoInterceptor>(
-  'TRANSLOCO_INTERCEPTOR',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_INTERCEPTOR' : '',
 );
 
 export interface TranslocoInterceptor {

--- a/libs/transloco/src/lib/transloco.loader.ts
+++ b/libs/transloco/src/lib/transloco.loader.ts
@@ -23,5 +23,5 @@ export class DefaultLoader implements TranslocoLoader {
 }
 
 export const TRANSLOCO_LOADER = new InjectionToken<TranslocoLoader>(
-  'TRANSLOCO_LOADER',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_LOADER' : '',
 );

--- a/libs/transloco/src/lib/transloco.transpiler.ts
+++ b/libs/transloco/src/lib/transloco.transpiler.ts
@@ -9,7 +9,7 @@ import {
 } from './transloco.config';
 
 export const TRANSLOCO_TRANSPILER = new InjectionToken<TranslocoTranspiler>(
-  'TRANSLOCO_TRANSPILER',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_TRANSPILER' : '',
 );
 
 export interface TranslocoTranspiler {

--- a/libs/transloco/src/lib/types.ts
+++ b/libs/transloco/src/lib/types.ts
@@ -50,3 +50,11 @@ export interface LoadOptions {
   failedCounter?: number;
   inlineLoader?: InlineLoader;
 }
+
+/** @internal */
+declare global {
+  // Indicates whether the application is operating in development mode.
+  // `ngDevMode` is a global flag set by Angular CLI.
+  // https://github.com/angular/angular-cli/blob/9b883fe28862c96720c7899b431174e9b47ad7e4/packages/angular/build/src/tools/esbuild/application-code-bundle.ts#L604
+  const ngDevMode: boolean;
+}


### PR DESCRIPTION
In this commit, we tree-shake injection token names in production by inlining the `ngDevMode` condition. This is the same approach that Angular uses.

See, for instance: https://tinyurl.com/4y9dxzsp (long GitHub URL).

`ngDevMode` cannot be extracted into a separate shared variable, as this would result in a separate runtime variable. The condition must always be inlined for the minifier to work correctly.