### PR TITLE
chore(transloco-util): add keysManager.sort key to TranslocoGlobalConfig

### DIFF
--- a/libs/transloco-utils/src/lib/transloco-utils.types.ts
+++ b/libs/transloco-utils/src/lib/transloco-utils.types.ts
@@ -14,5 +14,6 @@ export interface TranslocoGlobalConfig {
     replace?: boolean;
     defaultValue?: string | undefined;
     unflat?: boolean;
+    sort?: boolean;
   };
 }


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngneat/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Types

## What is the current behavior?

No property  `keysManager.sort` in the `TranslocoGlobalConfig` interface.

Issue Number: #825

## What is the new behavior?

Expose property `keysManager.sort` for `TranslocoGlobalConfig` publically.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I'm not sure if there should be a documentation change for the page hosted under https://jsverse.gitbook.io/transloco/tools/keys-manager-tkm/options#transloco-config-file. I would apprechiate some input for this question.