### PR TITLE
refactor(core): tree-shake unused injection tokens

### DIFF
--- a/libs/transloco/src/lib/transloco-fallback-strategy.ts
+++ b/libs/transloco/src/lib/transloco-fallback-strategy.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable, InjectionToken } from '@angular/core';
 import { TRANSLOCO_CONFIG, TranslocoConfig } from './transloco.config';
 
 export const TRANSLOCO_FALLBACK_STRATEGY =
-  new InjectionToken<TranslocoFallbackStrategy>(
+  /* @__PURE__ */ new InjectionToken<TranslocoFallbackStrategy>(
     typeof ngDevMode !== 'undefined' && ngDevMode
       ? 'TRANSLOCO_FALLBACK_STRATEGY'
       : '',

--- a/libs/transloco/src/lib/transloco-lang.ts
+++ b/libs/transloco/src/lib/transloco-lang.ts
@@ -1,5 +1,5 @@
 import { InjectionToken } from '@angular/core';
 
-export const TRANSLOCO_LANG = new InjectionToken<string>(
+export const TRANSLOCO_LANG = /* @__PURE__ */ new InjectionToken<string>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_LANG' : '',
 );

--- a/libs/transloco/src/lib/transloco-loading-template.ts
+++ b/libs/transloco/src/lib/transloco-loading-template.ts
@@ -2,8 +2,9 @@ import { InjectionToken } from '@angular/core';
 
 import { Content } from './template-handler';
 
-export const TRANSLOCO_LOADING_TEMPLATE = new InjectionToken<Content>(
-  typeof ngDevMode !== 'undefined' && ngDevMode
-    ? 'TRANSLOCO_LOADING_TEMPLATE'
-    : '',
-);
+export const TRANSLOCO_LOADING_TEMPLATE =
+  /* @__PURE__ */ new InjectionToken<Content>(
+    typeof ngDevMode !== 'undefined' && ngDevMode
+      ? 'TRANSLOCO_LOADING_TEMPLATE'
+      : '',
+  );

--- a/libs/transloco/src/lib/transloco-missing-handler.ts
+++ b/libs/transloco/src/lib/transloco-missing-handler.ts
@@ -4,7 +4,7 @@ import { TranslocoConfig } from './transloco.config';
 import { HashMap } from './types';
 
 export const TRANSLOCO_MISSING_HANDLER =
-  new InjectionToken<TranslocoMissingHandlerData>(
+  /* @__PURE__ */ new InjectionToken<TranslocoMissingHandlerData>(
     typeof ngDevMode !== 'undefined' && ngDevMode
       ? 'TRANSLOCO_MISSING_HANDLER'
       : '',

--- a/libs/transloco/src/lib/transloco-scope.ts
+++ b/libs/transloco/src/lib/transloco-scope.ts
@@ -2,6 +2,7 @@ import { InjectionToken } from '@angular/core';
 
 import { TranslocoScope } from './types';
 
-export const TRANSLOCO_SCOPE = new InjectionToken<TranslocoScope>(
-  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_SCOPE' : '',
-);
+export const TRANSLOCO_SCOPE =
+  /* @__PURE__ */ new InjectionToken<TranslocoScope>(
+    typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_SCOPE' : '',
+  );

--- a/libs/transloco/src/lib/transloco-testing.module.ts
+++ b/libs/transloco/src/lib/transloco-testing.module.ts
@@ -21,12 +21,13 @@ export interface TranslocoTestingOptions {
   langs?: HashMap<Translation>;
 }
 
-const TRANSLOCO_TEST_LANGS = new InjectionToken<HashMap<Translation>>(
-  'TRANSLOCO_TEST_LANGS - Available testing languages',
-);
-const TRANSLOCO_TEST_OPTIONS = new InjectionToken<TranslocoTestingOptions>(
-  'TRANSLOCO_TEST_OPTIONS - Testing options',
-);
+const TRANSLOCO_TEST_LANGS = /* @__PURE__ */ new InjectionToken<
+  HashMap<Translation>
+>('TRANSLOCO_TEST_LANGS - Available testing languages');
+const TRANSLOCO_TEST_OPTIONS =
+  /* @__PURE__ */ new InjectionToken<TranslocoTestingOptions>(
+    'TRANSLOCO_TEST_OPTIONS - Testing options',
+  );
 
 @Injectable()
 export class TestingLoader implements TranslocoLoader {

--- a/libs/transloco/src/lib/transloco.config.ts
+++ b/libs/transloco/src/lib/transloco.config.ts
@@ -23,13 +23,14 @@ export interface TranslocoConfig {
   };
 }
 
-export const TRANSLOCO_CONFIG = new InjectionToken<TranslocoConfig>(
-  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_CONFIG' : '',
-  {
-    providedIn: 'root',
-    factory: () => defaultConfig,
-  },
-);
+export const TRANSLOCO_CONFIG =
+  /* @__PURE__ */ new InjectionToken<TranslocoConfig>(
+    typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_CONFIG' : '',
+    {
+      providedIn: 'root',
+      factory: () => defaultConfig,
+    },
+  );
 
 export const defaultConfig: TranslocoConfig = {
   defaultLang: 'en',

--- a/libs/transloco/src/lib/transloco.interceptor.ts
+++ b/libs/transloco/src/lib/transloco.interceptor.ts
@@ -2,9 +2,12 @@ import { InjectionToken, Injectable } from '@angular/core';
 
 import { Translation } from './types';
 
-export const TRANSLOCO_INTERCEPTOR = new InjectionToken<TranslocoInterceptor>(
-  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_INTERCEPTOR' : '',
-);
+export const TRANSLOCO_INTERCEPTOR =
+  /* @__PURE__ */ new InjectionToken<TranslocoInterceptor>(
+    typeof ngDevMode !== 'undefined' && ngDevMode
+      ? 'TRANSLOCO_INTERCEPTOR'
+      : '',
+  );
 
 export interface TranslocoInterceptor {
   preSaveTranslation(translation: Translation, lang: string): Translation;

--- a/libs/transloco/src/lib/transloco.loader.ts
+++ b/libs/transloco/src/lib/transloco.loader.ts
@@ -22,6 +22,7 @@ export class DefaultLoader implements TranslocoLoader {
   }
 }
 
-export const TRANSLOCO_LOADER = new InjectionToken<TranslocoLoader>(
-  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_LOADER' : '',
-);
+export const TRANSLOCO_LOADER =
+  /* @__PURE__ */ new InjectionToken<TranslocoLoader>(
+    typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_LOADER' : '',
+  );

--- a/libs/transloco/src/lib/transloco.transpiler.ts
+++ b/libs/transloco/src/lib/transloco.transpiler.ts
@@ -8,9 +8,10 @@ import {
   TranslocoConfig,
 } from './transloco.config';
 
-export const TRANSLOCO_TRANSPILER = new InjectionToken<TranslocoTranspiler>(
-  typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_TRANSPILER' : '',
-);
+export const TRANSLOCO_TRANSPILER =
+  /* @__PURE__ */ new InjectionToken<TranslocoTranspiler>(
+    typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_TRANSPILER' : '',
+  );
 
 export interface TranslocoTranspiler {
   transpile(params: TranspileParams): any;


### PR DESCRIPTION
`new` expressions are not dropped by default, because they are considered side-effectful.