### PR TITLE
feat(transloco): improve locale initialization and subscription handling

### DIFF
--- a/libs/transloco-locale/src/lib/transloco-locale.service.ts
+++ b/libs/transloco-locale/src/lib/transloco-locale.service.ts
@@ -46,8 +46,7 @@ export class TranslocoLocaleService implements OnDestroy {
 
   constructor() {
     // Initialize locale with fallback chain
-    this._locale = this.initializeLocale();
-    this.locale.next(this._locale);
+    this.setLocale(this.initializeLocale());
 
     // Subscribe to language changes
     this.subscription = this.translocoService.langChanges$

--- a/libs/transloco-locale/src/lib/transloco-locale.service.ts
+++ b/libs/transloco-locale/src/lib/transloco-locale.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, OnDestroy } from '@angular/core';
-import { TranslocoService } from '@jsverse/transloco';
+import { getBrowserCultureLang, TranslocoService } from '@jsverse/transloco';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 
@@ -36,7 +36,7 @@ export class TranslocoLocaleService implements OnDestroy {
   private numberTransformer = inject(TRANSLOCO_NUMBER_TRANSFORMER);
   private dateTransformer = inject(TRANSLOCO_DATE_TRANSFORMER);
   private localeConfig: LocaleConfig = inject(TRANSLOCO_LOCALE_CONFIG);
-  private browserLocale = navigator?.language || this.defaultLocale;
+  private browserLocale = getBrowserCultureLang() || this.defaultLocale;
 
   private _locale = '';
   private locale: BehaviorSubject<Locale> = new BehaviorSubject(this._locale);
@@ -170,6 +170,14 @@ export class TranslocoLocaleService implements OnDestroy {
 
     return '';
   }
+
+  /*
+   * Get the browser's language and validate.
+   * If the browser's language is not set, it will fall back to the default locale.
+   * If the default locale is not set, it will use the active language from TranslocoService.
+   * If no active language is set, it will default to "en-US".
+   * @returns {Locale} The browser's default locale in the format "en-US".
+   */
 
   private initializeLocale(): Locale {
     const browserLocale = this.toLocale(this.browserLocale);

--- a/libs/transloco-locale/src/lib/transloco-locale.service.ts
+++ b/libs/transloco-locale/src/lib/transloco-locale.service.ts
@@ -172,18 +172,18 @@ export class TranslocoLocaleService implements OnDestroy {
   }
 
   private initializeLocale(): Locale {
-    // Try to get from active language first
+    const browserLocale = this.toLocale(this.browserLocale);
+    if (browserLocale) return browserLocale;
+
+    const defaultLocaleResolved = this.toLocale(this.defaultLocale);
+    if (defaultLocaleResolved) return defaultLocaleResolved;
+
     const activeLang = this.translocoService.getActiveLang();
     if (activeLang) {
       const locale = this.toLocale(activeLang);
       if (locale) return locale;
     }
 
-    // Fallback to browser locale
-    const browserLocale = this.toLocale(this.browserLocale);
-    if (browserLocale) return browserLocale;
-
-    // Final fallback to default locale
-    return this.toLocale(this.defaultLocale) || 'en-US';
+    return 'en-US'; // Fallback to a default locale
   }
 }


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

I’ve been working with both Transloco and TranslocoLocale, and I noticed a potential improvement in how locale is determined in TranslocoLocaleService.

Currently, the locale is derived using:

private _locale = this.defaultLocale || this.toLocale(this.translocoService.getActiveLang());

This assumes that the active language from TranslocoService (e.g., 'fr') can be reliably converted to a full locale (e.g., 'fr-FR'). However, this approach:

Ignores the user's actual browser locale (navigator.language or navigator.languages)
Doesn't account for user preferences or app-level overrides
May lead to incorrect formatting (e.g., 'fr' mapping to 'fr-FR' when the user is in Canada and expects 'fr-CA')
💡 Proposal
Enhance TranslocoLocaleService to:

Prefer navigator.language as the default locale if defaultLocale is not explicitly set.
Allow developers to provide a custom mapping or override logic via config.
Optionally sync locale with language changes in TranslocoService using a plugin or shared service.
🔧 Example Implementation

private browserLocale = navigator.language || this.defaultLocale;

private _locale =this.toLocale(browserLocale)


This would ensure that both translation and formatting are aligned with the user's actual environment.

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
