### PR TITLE
refactor(transloco): 💡 Allow DeepPartial for test module config

### DIFF
--- a/libs/transloco/src/lib/tests/testing-module.spec.ts
+++ b/libs/transloco/src/lib/tests/testing-module.spec.ts
@@ -1,0 +1,27 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TRANSLOCO_CONFIG } from '../transloco.config';
+import { TranslocoTestingModule } from '../transloco-testing.module';
+
+describe('TranslocoTestingModule', () => {
+  it('should accept missingHandler config but still provide logMissingKey default for testing', () => {
+    const testBed = TestBed.configureTestingModule({
+      imports: [
+        TranslocoTestingModule.forRoot({
+          langs: {},
+          translocoConfig: {
+            availableLangs: ['es', 'en'],
+            defaultLang: 'es',
+            missingHandler: {
+              allowEmpty: true,
+            },
+          },
+        }),
+      ],
+    });
+
+    const config = testBed.inject(TRANSLOCO_CONFIG);
+    expect(config.missingHandler.logMissingKey).toBe(false);
+    expect(config.missingHandler.allowEmpty).toBe(true);
+  });
+});

--- a/libs/transloco/src/lib/transloco-testing.module.ts
+++ b/libs/transloco/src/lib/transloco-testing.module.ts
@@ -12,11 +12,11 @@ import { TranslocoLoader } from './transloco.loader';
 import { HashMap, Translation } from './types';
 import { TranslocoModule } from './transloco.module';
 import { provideTransloco } from './transloco.providers';
-import { TranslocoConfig } from './transloco.config';
+import { PartialTranslocoConfig } from './transloco.config';
 import { TranslocoService } from './transloco.service';
 
 export interface TranslocoTestingOptions {
-  translocoConfig?: Partial<TranslocoConfig>;
+  translocoConfig?: PartialTranslocoConfig;
   preloadLangs?: boolean;
   langs?: HashMap<Translation>;
 }
@@ -68,8 +68,11 @@ export class TranslocoTestingModule {
           loader: TestingLoader,
           config: {
             prodMode: true,
-            missingHandler: { logMissingKey: false },
             ...options.translocoConfig,
+            missingHandler: {
+              logMissingKey: false,
+              ...options.translocoConfig?.missingHandler,
+            },
           },
         }),
         {


### PR DESCRIPTION
This allows developers using the TranslocoTestingModule to pass other options for missingHandler without duplicating the logMissingKey config already provided

<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
If you try to pass `{ allowEmpty: true }` as the missingHandler configuration for the testing module you will get the below typescript error, which requires developers to pass all properties of the missingHandler object. This type definition differs from older versions of transloco which only required a partial missingHandler object: https://github.com/jsverse/transloco/blob/transloco-3.2.0/libs/transloco/src/lib/transloco.config.ts#L14

```
Type '{ allowEmpty: true; }' is missing the following properties from type '{ logMissingKey: boolean; useFallbackTranslation: boolean; allowEmpty: boolean; }': logMissingKey, useFallbackTranslationts(2739)
transloco.config.ts(15, 3): The expected type comes from property 'missingHandler' which is declared here on type 'Partial<TranslocoConfig>'
```

## What is the new behavior?

You can now pass a DeepPartial of the transloco configuration to the TranslocoTestingModule and default values will be applied by the library, which is consistent with the developer experience in the library API.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
