### PR TITLE
fix(transloco): take the last provided scope on selectTranslate

### DIFF
--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -341,7 +341,7 @@ export class TranslocoService {
       return this.langChanges$.pipe(switchMap((lang) => load(lang)));
     }
 
-    lang = Array.isArray(lang) ? lang[0] : lang;
+    lang = Array.isArray(lang) ? lang[lang.length - 1] : lang;
     if (isScopeObject(lang)) {
       // it's a scope object.
       const providerScope = lang;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently we updated the way to provide the scope from:
```ts
{
    provide: TRANSLOCO_SCOPE,
    useValue: 'ourScope',
  }
```
to the util provided by transloco:
```ts
provideTranslocoScope({ scope: 'ourScope', loader })
```
and we started to see untranslated content.

Turns out it was because the util provides `multi: true`, inside our components, we get an array of scopes like:
```ts
[
  {
    scope: 'imported module',
    loader: { ... },
  },
  {
    scope: 'component module',
    loader: { ... },
  },
]
```

## What is the new behavior?

Currently `TranslocoService.selectTranslate()` takes the array of scopes, and only loads the first one.
Turns out, that the scope provided by the module is the last one, so with this PR the `TranslocoService` will load the scope provided last (at the end of the array).

I wonder if all the scopes in the array should be loaded instead.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

@jsverse/transloco v7.6.1