### PR TITLE
feat(transloco): 🎸 auto-detect public folder in ng-add

### DIFF
--- a/libs/transloco/schematics/ng-add/files/transloco-loader/transloco-loader.__ts__
+++ b/libs/transloco/schematics/ng-add/files/transloco-loader/transloco-loader.__ts__
@@ -7,6 +7,6 @@ export class TranslocoHttpLoader implements TranslocoLoader {
     private http = inject(HttpClient);
 
     getTranslation(lang: string) {
-        return this.http.get<Translation>(`<%= loaderPrefix %>/assets/i18n/${lang}.json`);
+        return this.http.get<Translation>(`<%= loaderPrefix %>/<%= urlPath %>${lang}.json`);
     }
 }

--- a/libs/transloco/schematics/ng-add/generators/http-loader.gen.ts
+++ b/libs/transloco/schematics/ng-add/generators/http-loader.gen.ts
@@ -3,14 +3,20 @@ import { apply, move, template, url } from '@angular-devkit/schematics';
 export interface CreateLoaderFileParams {
   ssr: boolean;
   loaderPath: string;
+  urlPath: string;
 }
 
-export function createLoaderFile({ ssr, loaderPath }: CreateLoaderFileParams) {
+export function createLoaderFile({
+  ssr,
+  loaderPath,
+  urlPath,
+}: CreateLoaderFileParams) {
   return apply(url(`./files/transloco-loader`), [
     template({
       // Replace the __ts__ with ts
       ts: 'ts',
       loaderPrefix: ssr ? '${environment.baseUrl}' : '',
+      urlPath: urlPath,
     }),
     move('/', loaderPath),
   ]);

--- a/libs/transloco/schematics/ng-add/ng-add.spec.ts
+++ b/libs/transloco/schematics/ng-add/ng-add.spec.ts
@@ -52,6 +52,131 @@ describe('ng add', () => {
       );
     });
   });
+
+  describe('Folder Detection', () => {
+    it('should use public/i18n for Angular 18+ projects with public folder', async () => {
+      const options: SchemaOptions = { project: 'bar' } as SchemaOptions;
+      const initialTree = await createWorkspace(schematicRunner);
+
+      // Create public folder to simulate Angular 18+
+      initialTree.create('/public/favicon.ico', '');
+
+      const tree = await schematicRunner.runSchematic(
+        'ng-add',
+        options,
+        initialTree,
+      );
+
+      expect(tree.files).toContain('/public/i18n/en.json');
+      expect(tree.files).toContain('/public/i18n/es.json');
+
+      // Check that loader uses correct URL path
+      const loaderContent = readFile(tree, 'app/transloco-loader.ts');
+      expect(loaderContent).toContain('/i18n/${lang}.json');
+      expect(loaderContent).not.toContain('/assets/i18n/');
+    });
+
+    it('should use src/assets/i18n for projects with assets folder', async () => {
+      const options: SchemaOptions = { project: 'bar' } as SchemaOptions;
+      const initialTree = await createWorkspace(schematicRunner);
+
+      // Create assets folder to simulate traditional Angular structure
+      initialTree.create('/projects/bar/src/assets/icons/icon.png', '');
+
+      const tree = await schematicRunner.runSchematic(
+        'ng-add',
+        options,
+        initialTree,
+      );
+
+      expect(tree.files).toContain('/projects/bar/src/assets/i18n/en.json');
+      expect(tree.files).toContain('/projects/bar/src/assets/i18n/es.json');
+
+      // Check that loader uses correct URL path
+      const loaderContent = readFile(tree, 'app/transloco-loader.ts');
+      expect(loaderContent).toContain('/assets/i18n/${lang}.json');
+    });
+
+    it('should respect custom path when specified', async () => {
+      const options: SchemaOptions = {
+        project: 'bar',
+        path: 'custom/translations/',
+      } as SchemaOptions;
+
+      const tree = await schematicRunner.runSchematic(
+        'ng-add',
+        options,
+        await createWorkspace(schematicRunner),
+      );
+
+      expect(tree.files).toContain(
+        '/projects/bar/src/custom/translations/en.json',
+      );
+      expect(tree.files).toContain(
+        '/projects/bar/src/custom/translations/es.json',
+      );
+
+      // Check that loader uses correct URL path
+      const loaderContent = readFile(tree, 'app/transloco-loader.ts');
+      expect(loaderContent).toContain('/custom/translations/${lang}.json');
+    });
+
+    it('should fallback to package.json version detection when folders are ambiguous', async () => {
+      const options: SchemaOptions = { project: 'bar' } as SchemaOptions;
+      const initialTree = await createWorkspace(schematicRunner);
+
+      // Simulate Angular 18+ by updating package.json
+      const packageJson = JSON.parse(
+        initialTree.read('/package.json')!.toString(),
+      );
+      packageJson.dependencies['@angular/core'] = '^18.0.0';
+      initialTree.overwrite(
+        '/package.json',
+        JSON.stringify(packageJson, null, 2),
+      );
+
+      const tree = await schematicRunner.runSchematic(
+        'ng-add',
+        options,
+        initialTree,
+      );
+
+      expect(tree.files).toContain('/public/i18n/en.json');
+      expect(tree.files).toContain('/public/i18n/es.json');
+
+      // Check that loader uses correct URL path for Angular 18+
+      const loaderContent = readFile(tree, 'app/transloco-loader.ts');
+      expect(loaderContent).toContain('/i18n/${lang}.json');
+    });
+
+    it('should fallback to assets for Angular <18 when package.json indicates older version', async () => {
+      const options: SchemaOptions = { project: 'bar' } as SchemaOptions;
+      const initialTree = await createWorkspace(schematicRunner);
+
+      // Simulate Angular 17 by updating package.json
+      const packageJson = JSON.parse(
+        initialTree.read('/package.json')!.toString(),
+      );
+      packageJson.dependencies['@angular/core'] = '^17.0.0';
+      initialTree.overwrite(
+        '/package.json',
+        JSON.stringify(packageJson, null, 2),
+      );
+
+      const tree = await schematicRunner.runSchematic(
+        'ng-add',
+        options,
+        initialTree,
+      );
+
+      expect(tree.files).toContain('/projects/bar/src/assets/i18n/en.json');
+      expect(tree.files).toContain('/projects/bar/src/assets/i18n/es.json');
+
+      // Check that loader uses correct URL path for Angular <18
+      const loaderContent = readFile(tree, 'app/transloco-loader.ts');
+      expect(loaderContent).toContain('/assets/i18n/${lang}.json');
+    });
+  });
 });
 
 function readFile(host: UnitTestTree, path: string) {

--- a/libs/transloco/schematics/ng-add/schema.json
+++ b/libs/transloco/schematics/ng-add/schema.json
@@ -33,7 +33,7 @@
     },
     "path": {
       "type": "string",
-      "default": "assets/i18n/",
+      "description": "Translation files path (auto-detects public/ for Angular 18+)",
       "alias": "p"
     },
     "project": {


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The ng-add schematic hardcodes the translation files path to `assets/i18n/`, which doesn't work properly with Angular 18+ projects that use the new `public/` folder structure instead of `src/assets/`.

Issue Number: #818

## What is the new behavior?

The ng-add schematic now automatically detects whether to use `public/i18n/` or `assets/i18n/` based on:
1. **Folder detection**: Checks if `/public` or `${sourceRoot}/assets` exists
2. **Version detection**: Falls back to checking Angular version in package.json (18+ uses `public/`)
3. **User override**: Respects explicit `--path` parameter if provided

This ensures translation files are placed in the correct location and the HTTP loader uses the right URL path for both modern and legacy Angular projects.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The implementation maintains full backward compatibility while adding intelligent detection for Angular 18+ projects. All existing projects continue to work as before, while new Angular 18+ projects automatically get the correct `public/` folder configuration.