### PR TITLE
fix(transloco): 🐛 Allow translateSignal API to access any scope

### DIFF
--- a/libs/transloco/src/lib/tests/service/selectTranslate.spec.ts
+++ b/libs/transloco/src/lib/tests/service/selectTranslate.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync } from '@angular/core/testing';
+import { fakeAsync, TestBed } from '@angular/core/testing';
 
 import { createService, runLoader, inlineScope } from '../mocks';
 import { TranslocoService } from '../../transloco.service';
@@ -200,6 +200,39 @@ describe('selectTranslate', () => {
         expect(spy).toHaveBeenCalledWith(
           'Replaces standard Transloco - spanish',
         );
+      }));
+
+      it(`GIVEN a TranslocoService with autoPrefixKeys=false
+          WHEN subscribing to selectTranslate with an array of scope objects using inline loaders
+          THEN should resolve the correct translations and translate the scoped key`, fakeAsync(() => {
+        TestBed.resetTestingModule();
+        service = createService({
+          scopes: {
+            autoPrefixKeys: false,
+          },
+        });
+
+        const spy = jasmine.createSpy();
+        const desiredScope = {
+          scope: 'lazy-page',
+          loader: {
+            en: () => Promise.resolve({ message: 'lazy-message' }),
+          },
+        };
+        const otherScope = {
+          scope: 'other-page',
+          loader: {
+            en: () => Promise.resolve({ message: 'other-message' }),
+          },
+        };
+
+        service
+          .selectTranslate('lazyPage.message', {}, [otherScope, desiredScope])
+          .subscribe(spy);
+
+        runLoader();
+
+        expect(spy).toHaveBeenCalledWith('lazy-message');
       }));
     });
   });


### PR DESCRIPTION
Use the autoPrefixKeys=false configuration to find the best provider scope based on the requested key(s), which will then wait for any inline loaders to resolve before trying to translate.

This also includes a small refactor to move the autoPrefixKeys configuration logic into a private function.

✅ Closes: [#875](https://github.com/jsverse/transloco/issues/875)

<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [#875](https://github.com/jsverse/transloco/issues/875)

Using an app.config.ts with multiple TRANSLOCO_SCOPE providers with inline loaders, you can select translations from either scope using the pipe or directive but only have access to the first scope with the translateSignal API.

## What is the new behavior?

To avoid introducing a breaking change but still fix this issue, we can utilize the new autoPrefixKeys configuration property from https://github.com/jsverse/transloco/pull/868. 

If the user has configured their transloco service to not automatically prefix the translation keys with the requested scopes then their translation keys will contain the full path of the translation, including the requested scope. We can utilize that full path to find the correct transloco scope in the providers array to support any inline loaders for that scope.

This PR does not address requesting translations from multiple scopes with inline loaders, if someone needs to do that they should create separate signals.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

