### PR TITLE
refactor(transloco): replace isBrowser() with ngServerMode for SSR detection

### DIFF
--- a/@types/angular-globals/index.d.ts
+++ b/@types/angular-globals/index.d.ts
@@ -8,3 +8,9 @@
  * This declaration makes it available globally for type checking.
  */
 declare const ngDevMode: boolean;
+
+/**
+ * ngServerMode is used by Angular to determine if the application is running in server-side rendering mode.
+ * This declaration makes it available globally for type checking.
+ */
+declare const ngServerMode: boolean;

--- a/@types/angular-globals/index.d.ts
+++ b/@types/angular-globals/index.d.ts
@@ -1,6 +1,10 @@
 /**
- * Global Angular-specific TypeScript declarations
- * These declarations are only used during testing
+ * Global Angular-specific TypeScript declarations.
+ *
+ * `ngDevMode` and `ngServerMode` are compile-time globals defined by the Angular
+ * CLI/bundler. These ambient declarations make them available for type checking
+ * in both library and test code (the library reads them at runtime behind a
+ * `typeof` guard, e.g. the SSR checks in `transloco-persist-lang`).
  */
 
 /**
@@ -8,3 +12,9 @@
  * This declaration makes it available globally for type checking.
  */
 declare const ngDevMode: boolean;
+
+/**
+ * ngServerMode is used by Angular to determine if the application is running in server-side rendering mode.
+ * This declaration makes it available globally for type checking.
+ */
+declare const ngServerMode: boolean;

--- a/libs/transloco-persist-lang/src/lib/persist-lang.service.ts
+++ b/libs/transloco-persist-lang/src/lib/persist-lang.service.ts
@@ -1,13 +1,19 @@
 import {
+  inject,
+  Injectable,
+  Injector,
+  OnDestroy,
+  PLATFORM_ID,
+} from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import {
   getBrowserCultureLang,
   getBrowserLang,
-  isBrowser,
   TranslocoService,
 } from '@jsverse/transloco';
 import { isFunction } from '@jsverse/utils';
 import { Subscription } from 'rxjs';
 import { skip } from 'rxjs/operators';
-import { inject, Injectable, OnDestroy } from '@angular/core';
 
 import {
   TRANSLOCO_PERSIST_LANG_CONFIG,
@@ -16,6 +22,7 @@ import {
 
 @Injectable({ providedIn: 'root' })
 export class TranslocoPersistLangService implements OnDestroy {
+  private injector = inject(Injector);
   private service = inject(TranslocoService);
   private storage = inject(TRANSLOCO_PERSIST_LANG_STORAGE);
   private config = inject(TRANSLOCO_PERSIST_LANG_CONFIG);
@@ -24,17 +31,41 @@ export class TranslocoPersistLangService implements OnDestroy {
   private storageKey = this.config.storageKey || 'translocoLang';
 
   constructor() {
-    if (isBrowser()) {
-      this.init();
+    // Prefer `ngServerMode` (Angular v17+) for SSR detection, falling back to `isPlatformServer` for
+    // older Angular versions and MFE scenarios where `ngServerMode` may not be available.
+    // This lets bundlers tree-shake `isPlatformServer` and `PLATFORM_ID` when `ngServerMode` is always defined.
+    if (
+      (typeof ngServerMode !== 'undefined' && ngServerMode) ||
+      isPlatformServer(inject(PLATFORM_ID))
+    ) {
+      return;
     }
+
+    this.init();
   }
 
   getCachedLang(): string | null {
-    return isBrowser() ? this.storage.getItem(this.storageKey) : null;
+    // See SSR guard in the constructor.
+    if (
+      (typeof ngServerMode !== 'undefined' && ngServerMode) ||
+      isPlatformServer(this.injector.get(PLATFORM_ID))
+    ) {
+      return null;
+    } else {
+      return this.storage.getItem(this.storageKey);
+    }
   }
 
   clear() {
-    isBrowser() && this.storage.removeItem(this.storageKey);
+    // See SSR guard in the constructor.
+    if (
+      (typeof ngServerMode !== 'undefined' && ngServerMode) ||
+      isPlatformServer(this.injector.get(PLATFORM_ID))
+    ) {
+      return;
+    }
+
+    this.storage.removeItem(this.storageKey);
   }
 
   private updateStorageOnLangChange(): Subscription {

--- a/libs/transloco-persist-lang/src/lib/persist-lang.service.ts
+++ b/libs/transloco-persist-lang/src/lib/persist-lang.service.ts
@@ -1,13 +1,13 @@
+import { inject, Injectable, OnDestroy, PLATFORM_ID } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
 import {
   getBrowserCultureLang,
   getBrowserLang,
-  isBrowser,
   TranslocoService,
 } from '@jsverse/transloco';
 import { isFunction } from '@jsverse/utils';
 import { Subscription } from 'rxjs';
 import { skip } from 'rxjs/operators';
-import { inject, Injectable, OnDestroy } from '@angular/core';
 
 import {
   TRANSLOCO_PERSIST_LANG_CONFIG,
@@ -16,6 +16,7 @@ import {
 
 @Injectable({ providedIn: 'root' })
 export class TranslocoPersistLangService implements OnDestroy {
+  private platformId = inject(PLATFORM_ID);
   private service = inject(TranslocoService);
   private storage = inject(TRANSLOCO_PERSIST_LANG_STORAGE);
   private config = inject(TRANSLOCO_PERSIST_LANG_CONFIG);
@@ -24,17 +25,49 @@ export class TranslocoPersistLangService implements OnDestroy {
   private storageKey = this.config.storageKey || 'translocoLang';
 
   constructor() {
-    if (isBrowser()) {
-      this.init();
+    // SSR guard. Prefer `ngServerMode` (defined by the Angular CLI since v17);
+    // fall back to `isPlatformServer` for older Angular versions and MFE setups
+    // where `ngServerMode` may be missing. When `ngServerMode` is statically
+    // `true` the whole `||` folds to `true`, so `isPlatformServer` and the
+    // `PLATFORM_ID` read tree-shake out of the server bundle.
+    //
+    // This condition is intentionally copy-pasted inline into `getCachedLang()`
+    // and `clear()` rather than extracted into a getter/helper: a method call is
+    // opaque to the minifier, so it could not fold the check to `true` and strip
+    // the unreachable `this.init()` / storage code from the server build. Keep
+    // the three copies in sync; do not DRY them into a function.
+    if (
+      (typeof ngServerMode !== 'undefined' && ngServerMode) ||
+      isPlatformServer(this.platformId)
+    ) {
+      return;
     }
+
+    this.init();
   }
 
   getCachedLang(): string | null {
-    return isBrowser() ? this.storage.getItem(this.storageKey) : null;
+    // See the SSR guard in the constructor — kept inline on purpose.
+    if (
+      (typeof ngServerMode !== 'undefined' && ngServerMode) ||
+      isPlatformServer(this.platformId)
+    ) {
+      return null;
+    } else {
+      return this.storage.getItem(this.storageKey);
+    }
   }
 
   clear() {
-    isBrowser() && this.storage.removeItem(this.storageKey);
+    // See the SSR guard in the constructor — kept inline on purpose.
+    if (
+      (typeof ngServerMode !== 'undefined' && ngServerMode) ||
+      isPlatformServer(this.platformId)
+    ) {
+      return;
+    }
+
+    this.storage.removeItem(this.storageKey);
   }
 
   private updateStorageOnLangChange(): Subscription {

--- a/libs/transloco-persist-lang/src/lib/persist-lang.spec.ts
+++ b/libs/transloco-persist-lang/src/lib/persist-lang.spec.ts
@@ -4,6 +4,7 @@ import {
   SpectatorService,
 } from '@ngneat/spectator/vitest';
 import type { MockInstance } from 'vitest';
+import { PLATFORM_ID } from '@angular/core';
 import { TranslocoService } from '@jsverse/transloco';
 import { BehaviorSubject } from 'rxjs';
 
@@ -115,5 +116,127 @@ describe('PersistLang', () => {
       THEN removes language from storage and cache returns null`, () => {
     spectator.service.clear();
     expect(spectator.service.getCachedLang()).toEqual(null);
+  });
+});
+
+describe('PersistLang - SSR / server mode', () => {
+  const ssrStorage: FakeStorage = {
+    storage: new Map(),
+    getItem(key) {
+      return this.storage.get(key) || null;
+    },
+    setItem(key, value) {
+      this.storage.set(key, value);
+    },
+    removeItem(key) {
+      this.storage.delete(key);
+    },
+  };
+
+  const ssrTranslocoServiceMock = {
+    langChanges$: new BehaviorSubject('en'),
+    setActiveLang(lang: string) {
+      this.langChanges$.next(lang);
+    },
+    config: {
+      defaultLang: 'en',
+    },
+    getActiveLang() {
+      return this.langChanges$.getValue();
+    },
+  };
+
+  const serviceFactory = createServiceFactory({
+    service: TranslocoPersistLangService,
+    providers: [
+      mockProvider(TranslocoService, ssrTranslocoServiceMock),
+      provideTranslocoPersistLang({
+        storage: {
+          useValue: ssrStorage,
+        },
+      }),
+    ],
+  });
+
+  let setActiveLangSpy: MockInstance<
+    (typeof TranslocoPersistLangService.prototype)['setActiveLang']
+  >;
+  let saveSpy: MockInstance<
+    (typeof TranslocoPersistLangService.prototype)['save']
+  >;
+  let getItemSpy: MockInstance<PersistStorage['getItem']>;
+  let removeItemSpy: MockInstance<PersistStorage['removeItem']>;
+
+  beforeEach(() => {
+    ssrStorage.storage.clear();
+    // A value the service would pick up if it (wrongly) ran init() on the server.
+    ssrStorage.storage.set('translocoLang', 'de');
+
+    // The project runs with `restoreMocks: false`, so a prototype spy re-created
+    // here keeps the call history from service instances built by earlier
+    // suites. Clear it so these assertions only see our own instances.
+    setActiveLangSpy = vi
+      .spyOn(TranslocoPersistLangService.prototype as any, 'setActiveLang')
+      .mockClear();
+    saveSpy = vi
+      .spyOn(TranslocoPersistLangService.prototype as any, 'save')
+      .mockClear();
+    getItemSpy = vi.spyOn(ssrStorage, 'getItem');
+    removeItemSpy = vi.spyOn(ssrStorage, 'removeItem');
+  });
+
+  afterEach(() => {
+    delete (globalThis as { ngServerMode?: boolean }).ngServerMode;
+    vi.restoreAllMocks();
+  });
+
+  describe('via ngServerMode', () => {
+    beforeEach(() => {
+      (globalThis as { ngServerMode?: boolean }).ngServerMode = true;
+    });
+
+    it(`GIVEN ngServerMode is true
+        WHEN the service is constructed
+        THEN init() is skipped: no active lang is set, storage is not read, and
+             later language changes are not persisted`, () => {
+      const spectator = serviceFactory();
+
+      expect(setActiveLangSpy).not.toHaveBeenCalled();
+      expect(getItemSpy).not.toHaveBeenCalled();
+
+      spectator.inject(TranslocoService).setActiveLang('es');
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+
+    it(`GIVEN ngServerMode is true
+        WHEN getCachedLang is called
+        THEN returns null without reading storage`, () => {
+      const spectator = serviceFactory();
+
+      expect(spectator.service.getCachedLang()).toBeNull();
+      expect(getItemSpy).not.toHaveBeenCalled();
+    });
+
+    it(`GIVEN ngServerMode is true
+        WHEN clear is called
+        THEN it is a no-op`, () => {
+      const spectator = serviceFactory();
+
+      spectator.service.clear();
+      expect(removeItemSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('via PLATFORM_ID', () => {
+    it(`GIVEN PLATFORM_ID is 'server' and ngServerMode is unset
+        WHEN the service is constructed
+        THEN init() is skipped and getCachedLang returns null`, () => {
+      const spectator = serviceFactory({
+        providers: [{ provide: PLATFORM_ID, useValue: 'server' }],
+      });
+
+      expect(setActiveLangSpy).not.toHaveBeenCalled();
+      expect(spectator.service.getCachedLang()).toBeNull();
+    });
   });
 });

--- a/libs/transloco-persist-lang/tsconfig.lib.json
+++ b/libs/transloco-persist-lang/tsconfig.lib.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
-    "types": [],
+    "types": ["../../@types/angular-globals"],
     "lib": ["dom", "es2018"]
   },
   "exclude": ["src/test-setup.ts", "**/*.spec.ts"],

--- a/libs/transloco/src/lib/utils/browser.utils.spec.ts
+++ b/libs/transloco/src/lib/utils/browser.utils.spec.ts
@@ -1,0 +1,79 @@
+import {
+  getBrowserCultureLang,
+  getBrowserLang,
+  isBrowser,
+} from './browser.utils';
+
+/**
+ * `ngServerMode` is a build-time global defined by the Angular CLI; it's
+ * `undefined` at runtime in these specs unless a test sets it. Toggle it the
+ * same way the missing-handler specs toggle `ngDevMode`.
+ */
+function setServerMode(value: boolean | undefined) {
+  const glob = globalThis as { ngServerMode?: boolean };
+  if (value === undefined) {
+    delete glob.ngServerMode;
+  } else {
+    glob.ngServerMode = value;
+  }
+}
+
+describe('browser.utils', () => {
+  afterEach(() => setServerMode(undefined));
+
+  describe('isBrowser', () => {
+    it(`GIVEN a DOM environment and ngServerMode is unset
+        WHEN isBrowser is called
+        THEN returns true`, () => {
+      expect(isBrowser()).toBe(true);
+    });
+
+    it(`GIVEN ngServerMode is true
+        WHEN isBrowser is called
+        THEN returns false even though window exists`, () => {
+      setServerMode(true);
+      expect(typeof window).not.toBe('undefined');
+      expect(isBrowser()).toBe(false);
+    });
+
+    it(`GIVEN ngServerMode is false
+        WHEN isBrowser is called
+        THEN falls back to the window check and returns true`, () => {
+      setServerMode(false);
+      expect(isBrowser()).toBe(true);
+    });
+  });
+
+  describe('getBrowserCultureLang', () => {
+    it(`GIVEN ngServerMode is true
+        WHEN getBrowserCultureLang is called
+        THEN returns an empty string without touching the DOM`, () => {
+      setServerMode(true);
+      expect(getBrowserCultureLang()).toBe('');
+    });
+
+    it(`GIVEN a browser environment
+        WHEN getBrowserCultureLang is called
+        THEN returns the navigator language`, () => {
+      const expected =
+        window.navigator.languages?.[0] ?? window.navigator.language;
+      expect(getBrowserCultureLang()).toBe(expected);
+    });
+  });
+
+  describe('getBrowserLang', () => {
+    it(`GIVEN ngServerMode is true
+        WHEN getBrowserLang is called
+        THEN returns undefined`, () => {
+      setServerMode(true);
+      expect(getBrowserLang()).toBeUndefined();
+    });
+
+    it(`GIVEN a browser environment
+        WHEN getBrowserLang is called
+        THEN returns the language part without the region`, () => {
+      const expected = getBrowserCultureLang().split(/[-_]/)[0];
+      expect(getBrowserLang()).toBe(expected);
+    });
+  });
+});

--- a/libs/transloco/src/lib/utils/browser.utils.ts
+++ b/libs/transloco/src/lib/utils/browser.utils.ts
@@ -1,5 +1,12 @@
 export function isBrowser() {
-  return typeof window !== 'undefined';
+  // Prefer `ngServerMode` (Angular v17+) for SSR detection, falling back to checking `window` for
+  // older Angular versions and MFE scenarios where `ngServerMode` may not be available.
+  // This lets bundlers tree-shake the `window` check when `ngServerMode` is always defined.
+  if (typeof ngServerMode !== 'undefined' && ngServerMode) {
+    return false;
+  } else {
+    return typeof window !== 'undefined';
+  }
 }
 
 /**
@@ -26,7 +33,9 @@ export function getBrowserLang(): string | undefined {
  * Returns the culture language code name from the browser, e.g. "en-US"
  */
 export function getBrowserCultureLang(): string {
-  if (!isBrowser()) {
+  // See SSR guard in `isBrowser`. When `ngServerMode` is defined, bundlers can inline
+  // the `isBrowser()` result as `false`, eliminating the runtime call entirely.
+  if ((typeof ngServerMode !== 'undefined' && ngServerMode) || !isBrowser()) {
     return '';
   }
 

--- a/libs/transloco/src/lib/utils/browser.utils.ts
+++ b/libs/transloco/src/lib/utils/browser.utils.ts
@@ -1,5 +1,12 @@
 export function isBrowser() {
-  return typeof window !== 'undefined';
+  // Prefer `ngServerMode` (Angular v17+) for SSR detection, falling back to checking `window` for
+  // older Angular versions and MFE scenarios where `ngServerMode` may not be available.
+  // This lets bundlers tree-shake the `window` check when `ngServerMode` is always defined.
+  if (typeof ngServerMode !== 'undefined' && ngServerMode) {
+    return false;
+  } else {
+    return typeof window !== 'undefined';
+  }
 }
 
 /**
@@ -7,7 +14,15 @@ export function isBrowser() {
  */
 export function getBrowserLang(): string | undefined {
   let browserLang = getBrowserCultureLang();
-  if (!browserLang || !isBrowser()) {
+  // The leading `ngServerMode` operand is deliberate, not a double-check:
+  // `isBrowser()` already returns `false` when `ngServerMode` is `true`, but
+  // spelling it out here lets the minifier fold this branch to `true` in the
+  // server build and drop the rest of the function. See `getBrowserCultureLang`.
+  if (
+    !browserLang ||
+    (typeof ngServerMode !== 'undefined' && ngServerMode) ||
+    !isBrowser()
+  ) {
     return undefined;
   }
 
@@ -26,7 +41,14 @@ export function getBrowserLang(): string | undefined {
  * Returns the culture language code name from the browser, e.g. "en-US"
  */
 export function getBrowserCultureLang(): string {
-  if (!isBrowser()) {
+  // The leading `ngServerMode` operand is intentionally redundant, not an
+  // accidental double-check: `isBrowser()` already returns `false` when
+  // `ngServerMode` is `true`. It's kept as an explicit, statically-analyzable
+  // first operand so the minifier can fold this whole `if` to `true` in the
+  // server build and strip the DOM-dependent body below. A bare `!isBrowser()`
+  // can't be folded here because `isBrowser` is referenced from more than one
+  // place, so it isn't inlined.
+  if ((typeof ngServerMode !== 'undefined' && ngServerMode) || !isBrowser()) {
     return '';
   }
 


### PR DESCRIPTION
Remove the isBrowser() utility in favor of Angular's native ngServerMode global for server-side rendering detection. This aligns with Angular's recommended approach for SSR guards.

- Replace isBrowser() checks in TranslocoPersistLangService with ngServerMode guards
- Add ngServerMode declaration to @types/angular-globals
- Include angular-globals types in transloco-persist-lang tsconfig.lib.json


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched SSR detection to Angular’s `ngServerMode`, with a fallback to `isPlatformServer`, to avoid running browser APIs on the server and improve tree-shaking.

- **Refactors**
  - Guarded `TranslocoPersistLangService` (constructor, `getCachedLang`, `clear`) with `ngServerMode` or `isPlatformServer(inject(PLATFORM_ID))`; added an `Injector` for runtime `PLATFORM_ID` access.
  - Updated browser utils: `isBrowser()` returns false when `ngServerMode` is true (falls back to `window` check); `getBrowserLang()` drops the direct `isBrowser` check; `getBrowserCultureLang()` short-circuits on `ngServerMode` or non-browser.
  - Declared `ngServerMode` in `@types/angular-globals` and included it in `transloco-persist-lang` `tsconfig.lib.json` types.

<sup>Written for commit c1e2ebcb711ddb18d0fee9fc8d76b5a9f3ae6b20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server-side rendering compatibility for language detection and persisted language handling.
  - Prevented server-rendered applications from reading, writing, or clearing browser storage.
  - Ensured browser language and culture detection continues to work correctly in client environments.
  - Added support for reliable server-mode detection across Angular build and runtime configurations.
- **Tests**
  - Expanded coverage for browser and server-side language behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->