### PR TITLE
fix(transloco): avoid duplicate fallback lang request when already cached

### DIFF
--- a/libs/transloco/src/lib/tests/service/missingHandler.spec.ts
+++ b/libs/transloco/src/lib/tests/service/missingHandler.spec.ts
@@ -102,4 +102,34 @@ describe('missingHandler', () => {
       expect(service.translate('empty', { value: 'hello' })).toEqual('');
     }));
   });
+
+  describe('useFallbackTranslation - no duplicate request', () => {
+    it(`GIVEN fallback lang is already cached
+        WHEN loading another lang with useFallbackTranslation
+        THEN should not make a duplicate request for the fallback lang`, fakeAsync(() => {
+      const service = createService({
+        // fallbackLang defaults to 'en' in createService, same as defaultLang
+        missingHandler: {
+          useFallbackTranslation: true,
+        },
+      });
+
+      const loaderSpy = spyOn(
+        (service as any).loader,
+        'getTranslation',
+      ).and.callThrough();
+
+      service.load('en').subscribe();
+      runLoader();
+
+      service.load('es').subscribe();
+      runLoader();
+
+      expect(loaderSpy).toHaveBeenCalledTimes(2);
+      expect(loaderSpy.calls.allArgs()).toEqual([
+        ['en', undefined],
+        ['es', undefined],
+      ]);
+    }));
+  });
 });

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -245,11 +245,43 @@ export class TranslocoService {
         ? `${scope!}/${this.firstFallbackLang}`
         : this.firstFallbackLang;
 
-      const loaders = getFallbacksLoaders({
-        ...loadersOptions,
-        fallbackPath: fallback!,
-      });
-      loadTranslation = forkJoin(loaders);
+      const cachedFallback = this.cache.get(fallback!);
+      if (cachedFallback) {
+        /**
+         * The fallback lang is already in the cache — either currently being fetched
+         * or fully loaded. Reuse it instead of calling the loader again.
+         *
+         * Without this guard, `getFallbacksLoaders` would call `resolveLoader`
+         * directly (bypassing the service cache) and issue a duplicate HTTP request.
+         *
+         * Example:
+         *   defaultLang: 'en', fallbackLang: 'en', useFallbackTranslation: true
+         *   A template contains both the active lang ('en') and a static 'es' lang.
+         *
+         *   1. load('en') — cache miss → HTTP GET /assets/i18n/en.json  (stored in cache)
+         *   2. load('es') — useFallbackTranslation('es') is true, fallback = 'en'
+         *                 → without this check, getFallbacksLoaders would HTTP GET
+         *                   /assets/i18n/en.json a second time despite it being cached.
+         *                 → with this check, the cached 'en' observable is reused and
+         *                   only /assets/i18n/es.json is fetched.
+         */
+        const primaryLoader = from(resolveLoader(loadersOptions)).pipe(
+          map((translation) => ({ translation, lang: path })),
+        );
+        const fallbackLoader = cachedFallback.pipe(
+          map(() => ({
+            translation: this.getTranslation(fallback!),
+            lang: fallback!,
+          })),
+        );
+        loadTranslation = forkJoin([primaryLoader, fallbackLoader]);
+      } else {
+        const loaders = getFallbacksLoaders({
+          ...loadersOptions,
+          fallbackPath: fallback!,
+        });
+        loadTranslation = forkJoin(loaders);
+      }
     } else {
       const loader = resolveLoader(loadersOptions);
       loadTranslation = from(loader);


### PR DESCRIPTION
When `useFallbackTranslation` is enabled, loading a secondary language (e.g. 'es') would internally call `getFallbacksLoaders`, which invokes `resolveLoader` directly — bypassing the service cache. This caused a duplicate HTTP request for the fallback lang whenever it had already been fetched (e.g. as the default lang).

Fix: before delegating to `getFallbacksLoaders`, check whether the fallback lang's observable is already in the cache. If it is, reuse it via a mapped `forkJoin` instead of issuing a new network request.

Adds a regression test covering the case where `fallbackLang` matches `defaultLang` and a second language is loaded afterward.

Closes #625 

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved translation loading performance by preventing redundant loader calls when fallback languages are already cached.

* **Tests**
  * Added test coverage for fallback language caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->