### PR TITLE
docs(v8): add "Use with Locize" recipe

### DIFF
--- a/docs/v8/SUMMARY.md
+++ b/docs/v8/SUMMARY.md
@@ -73,6 +73,7 @@
 * [Recipes](resources/recipies/README.md)
   * [Prefetch User Language](resources/recipies/prefetch-user-language.md)
   * [Using Xliff](resources/recipies/using-xliff.md)
+  * [Use with Locize](resources/recipies/use-with-locize.md)
   * [Generate Locale Files using Google Translate](resources/recipies/generate-locale-files-using-google-translate.md)
 * [Blog Posts](resources/blog-posts/README.md)
   * [Official Posts](resources/blog-posts/transloco-team-posts/README.md)

--- a/docs/v8/resources/recipies/use-with-locize.md
+++ b/docs/v8/resources/recipies/use-with-locize.md
@@ -113,10 +113,18 @@ write-enabled credential.
 **Never commit a Locize write apiKey to your repository.** Even with
 the `isDevMode()` guard, a hardcoded string literal still ends up in
 the dev bundle and (worse) in source control. Source it from a
-git-ignored env file (`.env.development`, `environment.ts` excluded
-from VCS, or a runtime config endpoint) and read it via your build
-tool's env-var injection (e.g. `import.meta.env.VITE_LOCIZE_APIKEY`
-for Vite-based builds, or a build-replaced constant).
+git-ignored env file or a build-replaced constant. How you wire that
+in depends on your Angular build:
+
+- **@angular/build (Vite-based, the Angular 17+ default):**
+  `import.meta.env.VITE_LOCIZE_APIKEY` after adding the key to a
+  git-ignored `.env.development` file.
+- **Webpack-based `@angular-devkit/build-angular:browser`:** the
+  classic `environments/environment.ts` file-replacement pattern,
+  with the real key in a git-ignored `environment.development.ts`
+  (or equivalent) that's only used by the dev configuration.
+- **Runtime fetch:** load `/api/config` from your own server at app
+  boot and pass the result into the handler.
 {% endhint %}
 
 ```typescript
@@ -130,8 +138,9 @@ import locizer from 'locizer';
 const projectId = '<your locize project id>';
 const namespace = 'translation';
 
-// Sourced from a git-ignored env file, not hardcoded.
-const devApiKey = import.meta.env.VITE_LOCIZE_APIKEY as string | undefined;
+// Source this from your build's env-var injection — see the warning
+// above for the per-bundler patterns. Never hardcode a real key here.
+const devApiKey: string | undefined = undefined;
 
 @Injectable({ providedIn: 'root' })
 export class LocizeMissingTranslationHandler implements TranslocoMissingHandler {

--- a/docs/v8/resources/recipies/use-with-locize.md
+++ b/docs/v8/resources/recipies/use-with-locize.md
@@ -1,0 +1,232 @@
+# Use with Locize
+
+[Locize](https://www.locize.com/?from=transloco-docs) is a translation
+management system built by the same team behind
+[i18next](https://www.i18next.com). It hosts your translation files on a
+CDN and ships an editor, review workflow, AI translation, and a
+`saveMissing` flow. This recipe wires Transloco to Locize via a custom
+`TranslocoLoader` (for reads) and a custom `TranslocoMissingHandler`
+(for `saveMissing`-style writes) — no Locize-specific plugin needed.
+
+{% stepper %}
+{% step %}
+### Install the `locizer` client
+
+[`locizer`](https://github.com/locize/locizer) is the lightweight
+framework-agnostic client for the Locize CDN. Transloco itself does the
+reads via `HttpClient`; `locizer` is only used here for the optional
+saveMissing flow.
+
+{% tabs %}
+{% tab title="pnpm" %}
+```bash
+pnpm add locizer
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```bash
+yarn add locizer
+```
+{% endtab %}
+
+{% tab title="npm" %}
+```bash
+npm install locizer
+```
+{% endtab %}
+{% endtabs %}
+{% endstep %}
+
+{% step %}
+### Implement a `TranslocoLoader` against the Locize CDN
+
+Locize serves translations at
+`https://{host}/{projectId}/{version}/{lang}/{namespace}` — pick the
+host according to your project's CDN type (see the
+[CDN endpoint](#locize-cdn-endpoint) section below).
+
+{% tabs %}
+{% tab title="Standalone" %}
+```typescript
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Translation, TranslocoLoader } from '@jsverse/transloco';
+
+const projectId = '<your locize project id>';
+const version = 'latest';
+const namespace = 'translation';
+// Standard CDN (default for new projects): 'https://api.lite.locize.app'
+// Pro CDN:                                  'https://api.locize.app'
+const locizeHost = 'https://api.lite.locize.app';
+
+@Injectable({ providedIn: 'root' })
+export class TranslocoHttpLoader implements TranslocoLoader {
+  private readonly http = inject(HttpClient);
+
+  getTranslation(lang: string) {
+    return this.http.get<Translation>(
+      `${locizeHost}/${projectId}/${version}/${lang}/${namespace}`,
+    );
+  }
+}
+```
+{% endtab %}
+
+{% tab title="NgModule" %}
+```typescript
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Translation, TranslocoLoader } from '@jsverse/transloco';
+
+const projectId = '<your locize project id>';
+const version = 'latest';
+const namespace = 'translation';
+const locizeHost = 'https://api.lite.locize.app'; // or 'https://api.locize.app' for Pro CDN
+
+@Injectable({ providedIn: 'root' })
+export class TranslocoHttpLoader implements TranslocoLoader {
+  constructor(private http: HttpClient) {}
+
+  getTranslation(lang: string) {
+    return this.http.get<Translation>(
+      `${locizeHost}/${projectId}/${version}/${lang}/${namespace}`,
+    );
+  }
+}
+```
+{% endtab %}
+{% endtabs %}
+{% endstep %}
+
+{% step %}
+### Implement a `TranslocoMissingHandler` that pushes new keys to Locize
+
+When a key is requested in the active language **and** the active
+language equals the default (reference) language, push the key to
+Locize so translators can fill it in. Guard the apiKey on `isDevMode()`
+so production builds never carry the write-enabled credential.
+
+```typescript
+import { Injectable, isDevMode } from '@angular/core';
+import {
+  TranslocoMissingHandler,
+  TranslocoMissingHandlerData,
+} from '@jsverse/transloco';
+import locizer from 'locizer';
+
+const projectId = '<your locize project id>';
+const namespace = 'translation';
+
+locizer.init({
+  projectId,
+  apiKey: isDevMode() ? '<your dev apiKey>' : undefined,
+  version: 'latest',
+  cdnType: 'standard', // or 'pro'
+});
+
+@Injectable({ providedIn: 'root' })
+export class LocizeMissingTranslationHandler implements TranslocoMissingHandler {
+  handle(key: string, data: TranslocoMissingHandlerData): string {
+    if (data.activeLang === data.defaultLang) {
+      locizer.add(namespace, key, key);
+    }
+    return key;
+  }
+}
+```
+{% endstep %}
+
+{% step %}
+### Wire both into `app.config.ts`
+
+{% tabs %}
+{% tab title="Standalone" %}
+```typescript
+import { ApplicationConfig, isDevMode } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  provideTransloco,
+  provideTranslocoMissingHandler,
+} from '@jsverse/transloco';
+import { TranslocoHttpLoader } from './transloco-http-loader';
+import { LocizeMissingTranslationHandler } from './transloco-missing-translation-handler';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideHttpClient(),
+    provideTransloco({
+      config: {
+        availableLangs: ['en', 'de'],
+        defaultLang: 'en',
+        fallbackLang: 'de',
+        reRenderOnLangChange: true,
+        prodMode: !isDevMode(),
+      },
+      loader: TranslocoHttpLoader,
+    }),
+    provideTranslocoMissingHandler(LocizeMissingTranslationHandler),
+  ],
+};
+```
+{% endtab %}
+
+{% tab title="NgModule" %}
+```typescript
+import { NgModule, isDevMode } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
+import {
+  provideTransloco,
+  provideTranslocoMissingHandler,
+  TranslocoModule,
+} from '@jsverse/transloco';
+import { TranslocoHttpLoader } from './transloco-http-loader';
+import { LocizeMissingTranslationHandler } from './transloco-missing-translation-handler';
+
+@NgModule({
+  imports: [HttpClientModule],
+  exports: [TranslocoModule],
+  providers: [
+    provideTransloco({
+      config: {
+        availableLangs: ['en', 'de'],
+        defaultLang: 'en',
+        fallbackLang: 'de',
+        reRenderOnLangChange: true,
+        prodMode: !isDevMode(),
+      },
+      loader: TranslocoHttpLoader,
+    }),
+    provideTranslocoMissingHandler(LocizeMissingTranslationHandler),
+  ],
+})
+export class TranslocoRootModule {}
+```
+{% endtab %}
+{% endtabs %}
+{% endstep %}
+{% endstepper %}
+
+## Locize CDN endpoint
+
+Locize ships two CDN infrastructures (full comparison at
+[CDN types: Standard vs. Pro](https://www.locize.com/docs/integration/cdn-types-standard-vs-pro?from=transloco-docs)):
+
+* **Standard CDN** at `api.lite.locize.app` — BunnyCDN-backed, free for
+  generous monthly download volumes, 1-hour fixed cache, public-only.
+  Default for newly created Locize projects.
+* **Pro CDN** at `api.locize.app` — CloudFront-backed, paid, supports
+  private downloads, custom cache control, and published-namespace
+  backups.
+
+Pick the host that matches your project's CDN type. Both serve the same
+URL shape.
+
+## Full example
+
+A complete Angular 21 + `@jsverse/transloco` 8 app using this pattern
+lives at
+[github.com/locize/transloco-example](https://github.com/locize/transloco-example).
+For the API reference and full URL shapes (auth, query options,
+caching), see the
+[Locize API docs](https://www.locize.com/docs/integration/api?from=transloco-docs).

--- a/docs/v8/resources/recipies/use-with-locize.md
+++ b/docs/v8/resources/recipies/use-with-locize.md
@@ -104,8 +104,20 @@ export class TranslocoHttpLoader implements TranslocoLoader {
 
 When a key is requested in the active language **and** the active
 language equals the default (reference) language, push the key to
-Locize so translators can fill it in. Guard the apiKey on `isDevMode()`
-so production builds never carry the write-enabled credential.
+Locize so translators can fill it in. `locizer.init` is called once
+from the handler's constructor (after Angular bootstrap) and the
+apiKey is gated on `isDevMode()` so production builds never carry the
+write-enabled credential.
+
+{% hint style="warning" %}
+**Never commit a Locize write apiKey to your repository.** Even with
+the `isDevMode()` guard, a hardcoded string literal still ends up in
+the dev bundle and (worse) in source control. Source it from a
+git-ignored env file (`.env.development`, `environment.ts` excluded
+from VCS, or a runtime config endpoint) and read it via your build
+tool's env-var injection (e.g. `import.meta.env.VITE_LOCIZE_APIKEY`
+for Vite-based builds, or a build-replaced constant).
+{% endhint %}
 
 ```typescript
 import { Injectable, isDevMode } from '@angular/core';
@@ -118,15 +130,21 @@ import locizer from 'locizer';
 const projectId = '<your locize project id>';
 const namespace = 'translation';
 
-locizer.init({
-  projectId,
-  apiKey: isDevMode() ? '<your dev apiKey>' : undefined,
-  version: 'latest',
-  cdnType: 'standard', // or 'pro'
-});
+// Sourced from a git-ignored env file, not hardcoded.
+const devApiKey = import.meta.env.VITE_LOCIZE_APIKEY as string | undefined;
 
 @Injectable({ providedIn: 'root' })
 export class LocizeMissingTranslationHandler implements TranslocoMissingHandler {
+  constructor() {
+    // Init once after Angular bootstrap so isDevMode() is reliable.
+    locizer.init({
+      projectId,
+      apiKey: isDevMode() ? devApiKey : undefined,
+      version: 'latest',
+      cdnType: 'standard', // or 'pro'
+    });
+  }
+
   handle(key: string, data: TranslocoMissingHandlerData): string {
     if (data.activeLang === data.defaultLang) {
       locizer.add(namespace, key, key);
@@ -174,7 +192,7 @@ export const appConfig: ApplicationConfig = {
 {% tab title="NgModule" %}
 ```typescript
 import { NgModule, isDevMode } from '@angular/core';
-import { HttpClientModule } from '@angular/common/http';
+import { provideHttpClient } from '@angular/common/http';
 import {
   provideTransloco,
   provideTranslocoMissingHandler,
@@ -184,9 +202,9 @@ import { TranslocoHttpLoader } from './transloco-http-loader';
 import { LocizeMissingTranslationHandler } from './transloco-missing-translation-handler';
 
 @NgModule({
-  imports: [HttpClientModule],
   exports: [TranslocoModule],
   providers: [
+    provideHttpClient(),
     provideTransloco({
       config: {
         availableLangs: ['en', 'de'],

--- a/docs/v8/resources/sandbox-and-examples.md
+++ b/docs/v8/resources/sandbox-and-examples.md
@@ -9,6 +9,10 @@ Explore Transloco in action with interactive demos and example repositories! The
 [🧪 Sandbox](https://codesandbox.io/s/jsverse-transloco-kn52hs)\
 [🎢 Playground](https://jsverse.github.io/transloco)
 
+### Example repositories
+
+* [locize/transloco-example](https://github.com/locize/transloco-example) — Angular 21 + Transloco 8 wired against the [Locize](https://www.locize.com/?from=transloco-docs) translation management CDN, with a custom `TranslocoMissingHandler` that pushes new keys back via `saveMissing`. See the matching [Use with Locize](recipies/use-with-locize.md) recipe.
+
 🚧 Some example repositories are still a work in progress—be sure to check back for updates!
 
 Have you created something extraordinary with Transloco? We'd love to feature it! Share your unique use cases, innovative solutions, or integrations with the community by opening a PR and adding them as resources. Together, we can grow and learn as a community 🤝


### PR DESCRIPTION
Adds a new Recipe page documenting how to use Transloco with [Locize](https://www.locize.com/?from=transloco-docs), per the contribution invitation on the [Sandbox & Examples](https://jsverse.gitbook.io/transloco/resources/sandbox-and-examples) page ("Share your unique use cases, innovative solutions, or integrations").

The recipe lives at `docs/v8/resources/recipies/use-with-locize.md` and walks through:

- Implementing a custom `TranslocoLoader` that fetches translations from the Locize CDN
- Implementing a custom `TranslocoMissingHandler` that pushes missing keys back via [`locizer`](https://github.com/locize/locizer) (analogous to i18next's `saveMissing`)
- Wiring both into `app.config.ts` via `provideTransloco` + `provideTranslocoMissingHandler` (Standalone and NgModule tabs, mirroring the existing Using Xliff recipe's format)

Both Locize CDN endpoints are documented:
- Standard CDN (`api.lite.locize.app`, BunnyCDN-backed, default for new projects)
- Pro CDN (`api.locize.app`, AWS CloudFront-backed)

Locize is maintained by the same team that builds i18next.

Also adds a one-line entry under "Example repositories" in `sandbox-and-examples.md` pointing at the companion runnable Angular 21 + Transloco 8 example at [github.com/locize/transloco-example](https://github.com/locize/transloco-example) (recently refreshed for the v8 standalone-components API).

Sidebar entry added to `SUMMARY.md` under Resources › Recipes.

Happy to adjust scope, wording, code-tab labels, or sidebar placement if a different shape would land better.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Use with Locize” recipe to the v8 docs showing how to load translations from Locize with `@jsverse/transloco` using a custom `TranslocoLoader`, plus a `TranslocoMissingHandler` (via `locizer`) to push missing keys. Updates the sidebar and examples, and adds bundler-agnostic guidance for sourcing the Locize API key.

- **New Features**
  - New recipe at `docs/v8/resources/recipies/use-with-locize.md` with Standalone and NgModule setup (`provideTransloco`, `provideTranslocoMissingHandler`, `provideHttpClient()`); initializes `locizer` in the handler constructor so `isDevMode()` runs post-bootstrap.
  - Bundler-agnostic API key guidance: covers `@angular/build` (Vite) env vars, webpack `@angular-devkit/build-angular` file-replacement, and runtime fetch; code uses a `devApiKey` placeholder and warns not to commit keys.
  - Documents Locize CDN endpoints: `api.lite.locize.app` (Standard) and `api.locize.app` (Pro). Adds `locize/transloco-example` to Sandbox & Examples and a sidebar entry in `SUMMARY.md`.

<sup>Written for commit da204179e3ad43727e7c56a7e4dd1879b8bf3409. Summary will update on new commits. <a href="https://cubic.dev/pr/jsverse/transloco/pull/922?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

