### PR TITLE
Allow values: empty string, 0 and false (valid JSON values)

### DIFF
--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -23,7 +23,7 @@ import {
   tap,
 } from 'rxjs';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
-import { isEmpty, isNil, isString, size, toCamelCase } from '@jsverse/utils';
+import { isDefined, isEmpty, isNil, isString, size, toCamelCase } from '@jsverse/utils';
 
 import {
   DefaultLoader,
@@ -342,7 +342,7 @@ export class TranslocoService {
     const translation = this.getTranslation(resolveLang);
     const value = translation[key];
 
-    if (!value) {
+    if (!isDefined(value)) {
       return this._handleMissingKey(key, value, params);
     }
 


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #927 

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow empty string, 0, and false translation values to be returned instead of treated as missing. Fixes incorrect missing-key handling for valid JSON values.

- **Bug Fixes**
  - In `TranslocoService`, use `isDefined` from `@jsverse/utils` when checking resolved keys so only undefined/null trigger the missing key handler.

<sup>Written for commit 76eb994c7354cfd59a23475f520d5cae27fb6a18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jsverse/transloco/pull/928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed translation service to properly handle falsy values (such as 0, empty strings, or false) — they are now correctly displayed instead of being treated as missing translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->