### PR TITLE
feat(TranslocoDirective): add useSignalTracking option to opt out of markForCheck

### DIFF
--- a/apps/transloco-playground/src/app/app.routes.ts
+++ b/apps/transloco-playground/src/app/app.routes.ts
@@ -10,6 +10,7 @@ import { SCOPE_SHARING_ROUTES } from './scope-sharing/scope-sharing.routes';
 import { TRANSPILERS_ROUTES } from './transpilers/transpilers.routes';
 import { MULTI_LANGS_ROUTES } from './multi-langs/multi-langs.routes';
 import { LOCALE_ROUTES } from './locale/locale.routes';
+import { SIGNAL_TRACKING_ROUTES } from './signal-tracking/signal-tracking.routes';
 
 export const ROUTES: Routes = [
   {
@@ -30,4 +31,5 @@ export const ROUTES: Routes = [
   SCOPE_SHARING_ROUTES,
   MULTI_LANGS_ROUTES,
   LOCALE_ROUTES,
+  SIGNAL_TRACKING_ROUTES
 ];

--- a/apps/transloco-playground/src/app/signal-tracking/signal-tracking.component.ts
+++ b/apps/transloco-playground/src/app/signal-tracking/signal-tracking.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { TranslocoModule } from '@jsverse/transloco';
+
+@Component({
+  selector: 'app-signal-tracking',
+  template: `
+    <ng-container *transloco="let t">
+      <h1 data-cy="st-title">{{ t('home') }}</h1>
+      <p data-cy="st-params">{{ t('alert', { value: '🦄' }) }}</p>
+      <p data-cy="st-nested">{{ t('a.b.c') }}</p>
+      <span data-cy="st-current-lang" *transloco="let t; currentLang as currentLang">{{ currentLang }}</span>
+    </ng-container>
+    <div data-cy="st-attribute" transloco="home"></div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [TranslocoModule],
+})
+export class SignalTrackingComponent {}

--- a/apps/transloco-playground/src/app/signal-tracking/signal-tracking.routes.ts
+++ b/apps/transloco-playground/src/app/signal-tracking/signal-tracking.routes.ts
@@ -1,0 +1,22 @@
+import { Route } from '@angular/router';
+
+import { TRANSLOCO_CONFIG, translocoConfig } from '@jsverse/transloco';
+
+export const SIGNAL_TRACKING_ROUTES: Route = {
+  path: 'signal-tracking',
+  loadComponent: () =>
+    import('./signal-tracking.component').then(
+      (m) => m.SignalTrackingComponent,
+    ),
+  providers: [
+    {
+      provide: TRANSLOCO_CONFIG,
+      useValue: translocoConfig({
+        availableLangs: ['en', 'es'],
+        reRenderOnLangChange: true,
+        defaultLang: 'en',
+        useSignalTracking: true,
+      }),
+    },
+  ],
+};

--- a/libs/transloco/src/lib/tests/directive/signal-tracking.spec.ts
+++ b/libs/transloco/src/lib/tests/directive/signal-tracking.spec.ts
@@ -1,0 +1,94 @@
+import { fakeAsync } from '@angular/core/testing';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
+
+import { provideTransloco } from '../../transloco.providers';
+import { translocoConfig } from '../../transloco.config';
+import { TranslocoDirective } from '../../transloco.directive';
+import { TranslocoService } from '../../transloco.service';
+import { MockedLoader, runLoader, setlistenToLangChange } from '../mocks';
+
+describe('Signal tracking (useSignalTracking: true)', () => {
+  let spectator: SpectatorHost<TranslocoDirective>;
+
+  const createHost = createHostFactory({
+    component: TranslocoDirective,
+    providers: [
+      provideTransloco({
+        config: translocoConfig({
+          availableLangs: ['en', 'es'],
+          useSignalTracking: true,
+        }),
+        loader: MockedLoader,
+      }),
+    ],
+  });
+
+  it('should render translations correctly with useSignalTracking enabled', fakeAsync(() => {
+    spectator = createHost(
+      `
+      <section *transloco="let t;">
+        <div>{{t('home')}}</div>
+        <span>{{t('a.b.c')}}</span>
+      </section>
+      `,
+      { detectChanges: false },
+    );
+    spectator.detectChanges();
+    runLoader();
+    spectator.detectChanges();
+    expect(spectator.queryHost('div')).toHaveText('home english');
+    expect(spectator.queryHost('span')).toHaveText('a.b.c from list english');
+  }));
+
+  it('should update translations on lang change without markForCheck', fakeAsync(() => {
+    spectator = createHost(
+      `
+      <section *transloco="let t;">
+        <div>{{t('home')}}</div>
+        <span>{{t('a.b.c')}}</span>
+      </section>
+      `,
+      { detectChanges: false },
+    );
+    const service = spectator.inject(TranslocoService);
+    setlistenToLangChange(service);
+
+    spectator.detectChanges();
+    runLoader();
+    spectator.detectChanges();
+    expect(spectator.queryHost('div')).toHaveText('home english');
+    expect(spectator.queryHost('span')).toHaveText('a.b.c from list english');
+
+    // Spy on directive's cdr AFTER initialization to verify markForCheck is not called on lang change
+    spyOn((spectator.component as any).cdr, 'markForCheck');
+
+    service.setActiveLang('es');
+    runLoader();
+    spectator.detectChanges();
+    expect(spectator.queryHost('div')).toHaveText('home spanish');
+    expect(spectator.queryHost('span')).toHaveText('a.b.c from list spanish');
+    expect((spectator.component as any).cdr.markForCheck).not.toHaveBeenCalled();
+  }));
+
+  it('should work with attribute directive without markForCheck', fakeAsync(() => {
+    spectator = createHost(`<div transloco="home"></div>`, {
+      detectChanges: false,
+    });
+    const service = spectator.inject(TranslocoService);
+    setlistenToLangChange(service);
+
+    spectator.detectChanges();
+    runLoader();
+    spectator.detectChanges();
+    expect(spectator.queryHost('[transloco]')).toHaveText('home english');
+
+    // Spy after init to verify lang change path doesn't call markForCheck
+    spyOn((spectator.component as any).cdr, 'markForCheck');
+
+    service.setActiveLang('es');
+    runLoader();
+    spectator.detectChanges();
+    expect(spectator.queryHost('[transloco]')).toHaveText('home spanish');
+    expect((spectator.component as any).cdr.markForCheck).not.toHaveBeenCalled();
+  }));
+});

--- a/libs/transloco/src/lib/transloco.config.ts
+++ b/libs/transloco/src/lib/transloco.config.ts
@@ -22,7 +22,7 @@ export interface TranslocoConfig {
     keepCasing?: boolean;
     autoPrefixKeys?: boolean;
   };
-  useSignalTracking: boolean;
+  useSignalTracking?: boolean;
 }
 
 export const TRANSLOCO_CONFIG =

--- a/libs/transloco/src/lib/transloco.config.ts
+++ b/libs/transloco/src/lib/transloco.config.ts
@@ -22,15 +22,16 @@ export interface TranslocoConfig {
     keepCasing?: boolean;
     autoPrefixKeys?: boolean;
   };
+  useSignalTracking: boolean;
 }
 
 export const TRANSLOCO_CONFIG =
   /* @__PURE__ */ new InjectionToken<TranslocoConfig>(
     typeof ngDevMode !== 'undefined' && ngDevMode ? 'TRANSLOCO_CONFIG' : '',
-    {
-      factory: () => defaultConfig,
-    },
-  );
+  {
+    factory: () => defaultConfig,
+  },
+);
 
 export const defaultConfig: TranslocoConfig = {
   defaultLang: 'en',
@@ -52,6 +53,7 @@ export const defaultConfig: TranslocoConfig = {
     keepCasing: false,
     autoPrefixKeys: true,
   },
+  useSignalTracking: false,
 };
 
 type DeepPartial<T> =

--- a/libs/transloco/src/lib/transloco.directive.ts
+++ b/libs/transloco/src/lib/transloco.directive.ts
@@ -10,6 +10,7 @@ import {
   OnDestroy,
   OnInit,
   Renderer2,
+  signal,
   SimpleChanges,
   TemplateRef,
   ViewContainerRef,
@@ -47,6 +48,7 @@ interface ViewContext {
 export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
   private destroyRef = inject(DestroyRef);
   private service = inject(TranslocoService);
+  private config = inject(TRANSLOCO_CONFIG);
   private tpl = inject<TemplateRef<ViewContext>>(TemplateRef, {
     optional: true,
   });
@@ -66,6 +68,7 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
   view: EmbeddedViewRef<ViewContext> | undefined;
 
   private memo = new Map<string, any>();
+  private translationsVersion = signal(0);
 
   @Input('transloco') key: string | undefined;
   @Input('translocoParams') params: HashMap = {};
@@ -128,7 +131,10 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
               this.currentLang,
               this.prefix || this.inlineRead,
             );
-        this.cdr.markForCheck();
+        this.translationsVersion.update(v => v + 1);
+        if (!this.config.useSignalTracking) {
+          this.cdr.markForCheck();
+        }
         this.initialized = true;
       });
 
@@ -181,6 +187,7 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
     prefix: string | undefined,
   ): TranslateFn {
     return (key: string, params?: HashMap) => {
+      this.translationsVersion(); // tracked read: triggers re-render when translations are loaded
       const withPrefix = prefix ? `${prefix}.${key}` : key;
       const memoKey = params
         ? `${withPrefix}${JSON.stringify(params)}`

--- a/libs/transloco/src/lib/transloco.directive.ts
+++ b/libs/transloco/src/lib/transloco.directive.ts
@@ -20,6 +20,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { OrArray } from '@jsverse/utils';
 
 import { Content, TemplateHandler } from './template-handler';
+import { TRANSLOCO_CONFIG } from './transloco.config';
 import { TRANSLOCO_LANG } from './transloco-lang';
 import { TRANSLOCO_LOADING_TEMPLATE } from './transloco-loading-template';
 import { TRANSLOCO_SCOPE } from './transloco-scope';


### PR DESCRIPTION
## Summary

Adds a new `useSignalTracking` configuration option that allows opting out of `markForCheck()` in the directive (TranslocoDirective), relying instead on Angular's signal-based change detection for granular template updates.

## Motivation

Currently, `TranslocoDirective` calls `ChangeDetectorRef.markForCheck()` after every translation load. This marks the entire host component (and its ancestor tree) as dirty, causing Angular to re-check all template bindings, not just the ones consuming translations.

With Angular 17+ signal components, the framework can track signal reads at the individual binding level. By reading a signal inside the `t()` function exposed to the template, Angular knows exactly which bindings depend on translation updates and can re-evaluate only those.

With signal-based change detection, Angular re-renders only the DOM nodes whose template bindings read the changed signal, rather than re-checking the entire component tree.

## How it works

A `translationsVersion` signal is bumped in the subscription callback (after translations are loaded). The translate function (`t('key')`) reads this signal on every invocation, creating a tracked dependency:

```typescript
// In the subscribe callback (after fetch completes):
this.translationsVersion.update(v => v + 1);
if (!this.config.useSignalTracking) {
  this.cdr.markForCheck();
}

// In the translate function exposed to the template:
return (key, params) => {
  this.translationsVersion(); // tracked read
  // ... translate
};
```

- **`useSignalTracking: false`** (default): `markForCheck()` is called as before. Fully backward compatible, zero behavior change.
- **`useSignalTracking: true`**: `markForCheck()` is skipped. Angular uses signal tracking to schedule re-evaluation.

## Breaking changes

None. The option defaults to `false`, preserving the existing `markForCheck()` behavior.

