### PR TITLE
fix(keys-manager): resolve scope alias, POT merge and process.exit issues from code review

### DIFF
--- a/libs/transloco-keys-manager/src/index.ts
+++ b/libs/transloco-keys-manager/src/index.ts
@@ -28,18 +28,41 @@ if (help) {
   process.exit();
 }
 
+const input = config.input
+  ?.split(',')
+  .map((path: string) => path.trim())
+  .filter((path: string) => path.length > 0);
+
+if (config.input && (!input || input.length === 0)) {
+  console.error('Please provide at least one valid input path.');
+  process.exit(1);
+}
+
 const resolvedConfig = {
   ...config,
   command: mainOptions.command,
-  ...(config.input ? { input: config.input.split(',') } : {}),
+  ...(input ? { input } : {}),
 } as Config;
 
-if (resolvedConfig.command === 'extract') {
-  warnUnsupportedOptions('extract', config);
-  buildTranslationFiles(resolvedConfig);
-} else if (resolvedConfig.command === 'find') {
-  warnUnsupportedOptions('find', config);
-  findMissingKeys(resolvedConfig);
-} else {
-  console.log(`Please provide an action...`);
+async function main() {
+  if (resolvedConfig.command === 'extract') {
+    warnUnsupportedOptions('extract', config);
+    await buildTranslationFiles(resolvedConfig);
+  } else if (resolvedConfig.command === 'find') {
+    warnUnsupportedOptions('find', config);
+    const { hasMissingKeys, hasExtraKeys } = findMissingKeys(resolvedConfig);
+    if (hasMissingKeys) {
+      process.exitCode = 1;
+    } else if (hasExtraKeys) {
+      process.exitCode = 2;
+    }
+  } else {
+    console.log(`Please provide an action...`);
+    process.exitCode = 1;
+  }
 }
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/libs/transloco-keys-manager/src/index.ts
+++ b/libs/transloco-keys-manager/src/index.ts
@@ -33,18 +33,19 @@ const input = config.input
   .map((path: string) => path.trim())
   .filter((path: string) => path.length > 0);
 
-if (config.input && (!input || input.length === 0)) {
-  console.error('Please provide at least one valid input path.');
-  process.exit(1);
-}
-
-const resolvedConfig = {
-  ...config,
-  command: mainOptions.command,
-  ...(input ? { input } : {}),
-} as Config;
-
 async function main() {
+  if (config.input !== undefined && (!input || input.length === 0)) {
+    console.error('Please provide at least one valid input path.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const resolvedConfig = {
+    ...config,
+    command: mainOptions.command,
+    ...(input ? { input } : {}),
+  } as Config;
+
   if (resolvedConfig.command === 'extract') {
     warnUnsupportedOptions('extract', config);
     await buildTranslationFiles(resolvedConfig);

--- a/libs/transloco-keys-manager/src/lib/keys-builder/index.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/index.ts
@@ -27,7 +27,7 @@ export async function buildTranslationFiles(inlineConfig: Config) {
 
   let keysFound = 0;
   for (const [_, scopeKeys] of Object.entries(scopeToKeys)) {
-    keysFound += countKeys(scopeKeys as object);
+    keysFound += countKeys(scopeKeys);
   }
 
   logger.log(

--- a/libs/transloco-keys-manager/src/lib/keys-builder/utils/create-translation.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/utils/create-translation.ts
@@ -46,8 +46,14 @@ function createJson(config: CreateTranslationOptions) {
 }
 
 function createPot(config: CreateTranslationOptions) {
-  const resolved: Translation = getConfig().unflat
-    ? flatten(resolveTranslation(config))
+  const { unflat } = getConfig();
+  const resolved: Translation = unflat
+    ? flatten(
+        resolveTranslation({
+          ...config,
+          translation: unflatten(config.translation, { object: true }),
+        }),
+      )
     : resolveTranslation(config);
 
   return po

--- a/libs/transloco-keys-manager/src/lib/keys-builder/utils/resolvers.utils.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/utils/resolvers.utils.ts
@@ -1,5 +1,6 @@
 import { LiteralPrimitive } from '@angular/compiler';
 
+import { getConfig } from '../../config';
 import { Scopes } from '../../types';
 import { isString } from '../../utils/validators.utils';
 
@@ -51,6 +52,13 @@ export function resolveScopeAlias({
 
   // Otherwise we're probably have a language in the scope: some/nested/en
   const splitted = scopePath.split('/');
+  const lastSegment = splitted[splitted.length - 1];
+
+  // Only remove the last segment if it's actually a configured language,
+  // otherwise it's part of the scope path itself.
+  if (!getConfig().langs.includes(lastSegment)) {
+    return undefined;
+  }
 
   // Remove the lang
   splitted.pop();

--- a/libs/transloco-keys-manager/src/lib/keys-builder/utils/scope.utils.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/utils/scope.utils.ts
@@ -4,6 +4,16 @@ let scopeToAlias: Scopes['scopeToAlias'] = {};
 let aliasToScope: Scopes['aliasToScope'] = {};
 
 export function addScope(scope: string, alias: string) {
+  const previousAlias = scopeToAlias[scope];
+  if (previousAlias !== undefined) {
+    delete aliasToScope[previousAlias];
+  }
+
+  const previousScope = aliasToScope[alias];
+  if (previousScope !== undefined) {
+    delete scopeToAlias[previousScope];
+  }
+
   scopeToAlias[scope] = alias;
   aliasToScope[alias] = scope;
 }

--- a/libs/transloco-keys-manager/src/lib/keys-detective/build-table.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-detective/build-table.ts
@@ -1,3 +1,4 @@
+import type { DiffDeleted, DiffNew } from 'deep-diff';
 import chalk from 'chalk';
 import Table from 'cli-table3';
 
@@ -12,23 +13,29 @@ type Params = {
   langs: string[];
   diffsPerLang: {
     [lang: string]: {
-      missing: any[];
-      extra: any[];
+      missing: DiffNew<any>[];
+      extra: DiffDeleted<any>[];
     };
   };
 };
+
+export interface BuildTableResult {
+  hasMissingKeys: boolean;
+  hasExtraKeys: boolean;
+}
 
 export function buildTable({
   langs,
   diffsPerLang,
   addMissingKeys,
   emitErrorOnExtraKeys,
-}: Params) {
+}: Params): BuildTableResult {
   const logger = getLogger();
-  if (langs.length > 0) {
-    let displayAddedMsg = false;
-    let hasExtraKeys = false;
+  let displayAddedMsg = false;
+  let hasExtraKeys = false;
+  let hasMissingKeys = false;
 
+  if (langs.length > 0) {
     logger.success(`\x1b[4m${messages.summary}\x1b[0m\n`);
     const table = new Table({
       style: {
@@ -52,6 +59,7 @@ export function buildTable({
       if (hasMissing) {
         row.push(mapDiffToKeys(missing, 'rhs'));
         displayAddedMsg = true;
+        hasMissingKeys = true;
       } else {
         row.push('--');
       }
@@ -69,17 +77,17 @@ export function buildTable({
     if (displayAddedMsg) {
       if (addMissingKeys) {
         logger.success(`Added all missing keys\n`);
-      } else {
-        process.exit(1);
+        hasMissingKeys = false;
       }
-    }
-
-    if (hasExtraKeys && emitErrorOnExtraKeys) {
-      process.exit(2);
     }
   } else {
     logger.log(`\n🎉 ${messages.noMissing} 🎉\n`);
   }
 
   logger.log('\n');
+
+  return {
+    hasMissingKeys: hasMissingKeys && !addMissingKeys,
+    hasExtraKeys: hasExtraKeys && emitErrorOnExtraKeys,
+  };
 }

--- a/libs/transloco-keys-manager/src/lib/keys-detective/compare-keys-to-files.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-detective/compare-keys-to-files.ts
@@ -1,11 +1,14 @@
 import { getGlobalConfig } from '@jsverse/transloco-utils';
 import type { DiffDeleted, DiffNew } from 'deep-diff';
 import df from 'deep-diff';
+import fs from 'fs-extra';
 import { flatten, unflatten } from 'flat';
 
 import { messages } from '../messages';
 import { Config, ScopeMap } from '../types';
-import { readFile, writeFile } from '../utils/file.utils';
+import { writeFile } from '../utils/file.utils';
+import { getCurrentTranslation } from '../keys-builder/utils/get-current-translation';
+import { createTranslation } from '../keys-builder/utils/create-translation';
 import { getLogger } from '../utils/logger';
 import { getScopeAndLangFromPath } from '../utils/path.utils';
 import { normalizedGlob } from '../utils/normalize-glob-path';
@@ -59,8 +62,10 @@ export function compareKeysToFiles({
 
   const result: Result[] = [];
   const scopePaths = getGlobalConfig().scopePathMap || {};
+  const cache: Record<string, boolean> = {};
   for (const [scope, path] of Object.entries(scopePaths)) {
     const keys = scopeToKeys[scope];
+    cache[scope] = true;
     if (keys) {
       const res: Omit<Result, 'files'> = {
         keys,
@@ -73,7 +78,6 @@ export function compareKeysToFiles({
       });
     }
   }
-  const cache: Record<string, boolean> = {};
 
   for (const filePath of translationFiles) {
     const { scope = '__global' } = getScopeAndLangFromPath({
@@ -110,7 +114,17 @@ export function compareKeysToFiles({
         translationsPath: baseFilesPath,
         fileFormat,
       });
-      const translation = readFile(filePath, { parse: true });
+      // We always keep the working translation flat, matching the on-disk
+      // POT format and the pre-unflatten shape of JSON files, so that diffs
+      // and mutations below operate on a consistent structure.
+      const rawTranslation = getCurrentTranslation({
+        path: filePath,
+        fileFormat,
+      });
+      const translation: Record<string, any> =
+        fileFormat === 'pot'
+          ? flatten<Record<string, any>, Record<string, any>>(rawTranslation)
+          : rawTranslation;
       // We always build the keys flatten, so we need to make sure we compare to a flat file
       const flat = flatten<Record<string, any>, Record<string, string>>(
         translation,
@@ -144,7 +158,20 @@ export function compareKeysToFiles({
         }
 
         if (addMissingKeys) {
-          writeFile(filePath, unflat ? unflatten(translation) : translation);
+          if (fileFormat === 'pot') {
+            fs.outputFileSync(
+              filePath,
+              createTranslation({
+                currentTranslation: {},
+                translation,
+                replace: true,
+                removeExtraKeys: false,
+                fileFormat,
+              }),
+            );
+          } else {
+            writeFile(filePath, unflat ? unflatten(translation) : translation);
+          }
         }
       }
     }
@@ -157,7 +184,7 @@ export function compareKeysToFiles({
     return missing.length || extra.length;
   });
 
-  buildTable({
+  return buildTable({
     langs,
     diffsPerLang,
     addMissingKeys,

--- a/libs/transloco-keys-manager/src/lib/keys-detective/index.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-detective/index.ts
@@ -21,7 +21,7 @@ export function findMissingKeys(inlineConfig: Config) {
 
   if (translationFiles.length === 0) {
     console.log('No translation files found.');
-    return;
+    return { hasMissingKeys: false, hasExtraKeys: false };
   }
 
   logger.log('\n 🕵 🔎', `\x1b[4m${messages.startSearch}\x1b[0m`, '🔍 🕵\n');
@@ -31,7 +31,7 @@ export function findMissingKeys(inlineConfig: Config) {
   logger.success(`${messages.extract} 🗝`);
 
   const { addMissingKeys, emitErrorOnExtraKeys, unflat } = config;
-  compareKeysToFiles({
+  return compareKeysToFiles({
     scopeToKeys: result.scopeToKeys,
     translationsPath,
     addMissingKeys,

--- a/libs/transloco-keys-manager/src/lib/marker.ts
+++ b/libs/transloco-keys-manager/src/lib/marker.ts
@@ -9,7 +9,7 @@
  */
 export function marker<T extends string | string[]>(
   key: T,
-  params?: undefined,
+  params?: Record<string, unknown>,
   scope?: string,
 ): T {
   return key;

--- a/libs/transloco-keys-manager/src/lib/tests/build-table.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/build-table.spec.ts
@@ -80,7 +80,7 @@ describe('buildTable', () => {
   });
 
   it('should call process.exit(1) when missing keys exist and addMissingKeys is false', () => {
-    buildTable({
+    const result = buildTable({
       langs: ['en'],
       diffsPerLang: {
         en: {
@@ -92,7 +92,7 @@ describe('buildTable', () => {
       emitErrorOnExtraKeys: false,
     });
 
-    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(result).toEqual({ hasMissingKeys: true, hasExtraKeys: false });
   });
 
   it('should log success when missing keys exist and addMissingKeys is true', () => {
@@ -121,11 +121,7 @@ describe('buildTable', () => {
   });
 
   it('should call process.exit(2) when extra keys exist and emitErrorOnExtraKeys is true', () => {
-    const exitSpy = vi
-      .spyOn(process, 'exit')
-      .mockImplementation((() => {}) as any);
-
-    buildTable({
+    const result = buildTable({
       langs: ['en'],
       diffsPerLang: {
         en: {
@@ -137,8 +133,7 @@ describe('buildTable', () => {
       emitErrorOnExtraKeys: true,
     });
 
-    expect(exitSpy).toHaveBeenCalledWith(2);
-    exitSpy.mockRestore();
+    expect(result).toEqual({ hasMissingKeys: false, hasExtraKeys: true });
   });
 
   it('should skip langs with no missing and no extra keys', () => {

--- a/libs/transloco-keys-manager/src/lib/tests/compare-keys-to-files.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/compare-keys-to-files.spec.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { po } from 'gettext-parser';
+import fs from 'fs-extra';
 
 import { compareKeysToFiles } from '../keys-detective/compare-keys-to-files';
 import { buildTable } from '../keys-detective/build-table';
@@ -6,6 +8,7 @@ import { normalizedGlob } from '../utils/normalize-glob-path';
 import { writeFile } from '../utils/file.utils';
 import { getCurrentTranslation } from '../keys-builder/utils/get-current-translation';
 import { getTranslationFilesPath } from '../keys-detective/get-translation-files-path';
+import { setConfig } from '../config';
 
 vi.mock('../utils/logger', () => ({
   getLogger: () => ({
@@ -30,6 +33,12 @@ vi.mock('../keys-detective/get-translation-files-path', () => ({
 vi.mock('../utils/file.utils', () => ({
   readFile: vi.fn(() => ({})),
   writeFile: vi.fn(),
+}));
+
+vi.mock('fs-extra', () => ({
+  default: {
+    outputFileSync: vi.fn(),
+  },
 }));
 
 vi.mock('../keys-builder/utils/get-current-translation', () => ({
@@ -190,5 +199,38 @@ describe('compareKeysToFiles', () => {
       '/tmp/i18n/en.json',
       expect.objectContaining({ a: { b: 'value' } }),
     );
+  });
+
+  it('should retain existing entries and add missing keys when writing a POT file', () => {
+    setConfig({ unflat: false } as any);
+    mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/en.pot']);
+    mockGetCurrentTranslation.mockReturnValue({
+      parent: { existing: 'existing value' },
+    });
+    mockNormalizedGlob.mockReturnValue(['/tmp/i18n/en.pot']);
+
+    compareKeysToFiles({
+      scopeToKeys: {
+        __global: {
+          'parent.existing': 'existing value',
+          'parent.newKey': 'new value',
+        },
+      },
+      translationsPath: '/tmp/i18n',
+      addMissingKeys: true,
+      emitErrorOnExtraKeys: false,
+      fileFormat: 'pot',
+      unflat: false,
+    });
+
+    const mockOutputFileSync = vi.mocked(fs.outputFileSync);
+    expect(mockOutputFileSync).toHaveBeenCalledTimes(1);
+    const [writtenPath, writtenContent] = mockOutputFileSync.mock.calls[0];
+    expect(writtenPath).toBe('/tmp/i18n/en.pot');
+
+    const parsed = po.parse(writtenContent as string, 'utf8');
+    const entries = parsed.translations[''];
+    expect(entries['parent.existing'].msgstr).toEqual(['existing value']);
+    expect(entries['parent.newKey'].msgstr).toEqual(['new value']);
   });
 });

--- a/libs/transloco-keys-manager/src/lib/tests/compare-keys-to-files.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/compare-keys-to-files.spec.ts
@@ -3,7 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { compareKeysToFiles } from '../keys-detective/compare-keys-to-files';
 import { buildTable } from '../keys-detective/build-table';
 import { normalizedGlob } from '../utils/normalize-glob-path';
-import { readFile, writeFile } from '../utils/file.utils';
+import { writeFile } from '../utils/file.utils';
+import { getCurrentTranslation } from '../keys-builder/utils/get-current-translation';
 import { getTranslationFilesPath } from '../keys-detective/get-translation-files-path';
 
 vi.mock('../utils/logger', () => ({
@@ -31,6 +32,10 @@ vi.mock('../utils/file.utils', () => ({
   writeFile: vi.fn(),
 }));
 
+vi.mock('../keys-builder/utils/get-current-translation', () => ({
+  getCurrentTranslation: vi.fn(() => ({})),
+}));
+
 vi.mock('@jsverse/transloco-utils', () => ({
   getGlobalConfig: () => ({ scopePathMap: {} }),
 }));
@@ -38,7 +43,7 @@ vi.mock('@jsverse/transloco-utils', () => ({
 describe('compareKeysToFiles', () => {
   const mockBuildTable = vi.mocked(buildTable);
   const mockNormalizedGlob = vi.mocked(normalizedGlob);
-  const mockReadFile = vi.mocked(readFile);
+  const mockGetCurrentTranslation = vi.mocked(getCurrentTranslation);
   const mockWriteFile = vi.mocked(writeFile);
   const mockGetTranslationFilesPath = vi.mocked(getTranslationFilesPath);
 
@@ -46,10 +51,7 @@ describe('compareKeysToFiles', () => {
     vi.clearAllMocks();
     mockNormalizedGlob.mockReturnValue([]);
     mockGetTranslationFilesPath.mockReturnValue([]);
-    mockReadFile.mockImplementation(((path: string, opts?: any) => {
-      if (opts?.parse) return {};
-      return '{}';
-    }) as any);
+    mockGetCurrentTranslation.mockReturnValue({});
   });
 
   it('should call buildTable with empty langs when no translation files', () => {
@@ -72,10 +74,7 @@ describe('compareKeysToFiles', () => {
       '/tmp/i18n/en.json',
       '/tmp/i18n/fr.json',
     ]);
-    mockReadFile.mockImplementation(((path: string, opts?: any) => {
-      if (opts?.parse) return { key: 'value' };
-      return '{"key":"value"}';
-    }) as any);
+    mockGetCurrentTranslation.mockReturnValue({ key: 'value' });
     mockNormalizedGlob.mockReturnValue(['/tmp/i18n/en.json']);
 
     compareKeysToFiles({
@@ -93,10 +92,7 @@ describe('compareKeysToFiles', () => {
 
   it('should detect missing keys and add them when addMissingKeys is true', () => {
     mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/en.json']);
-    mockReadFile.mockImplementation(((path: string, opts?: any) => {
-      if (opts?.parse) return { existing: 'val' };
-      return '{"existing":"val"}';
-    }) as any);
+    mockGetCurrentTranslation.mockReturnValue({ existing: 'val' });
     mockNormalizedGlob.mockReturnValue(['/tmp/i18n/en.json']);
 
     compareKeysToFiles({
@@ -118,10 +114,10 @@ describe('compareKeysToFiles', () => {
 
   it('should exclude comment deletions from extra keys', () => {
     mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/en.json']);
-    mockReadFile.mockImplementation(((path: string, opts?: any) => {
-      if (opts?.parse) return { key: 'value', 'key.comment': 'a comment' };
-      return '{}';
-    }) as any);
+    mockGetCurrentTranslation.mockReturnValue({
+      key: 'value',
+      'key.comment': 'a comment',
+    });
     mockNormalizedGlob.mockReturnValue(['/tmp/i18n/en.json']);
 
     compareKeysToFiles({
@@ -146,10 +142,7 @@ describe('compareKeysToFiles', () => {
 
   it('should namespace missing keys under the scope path (e.g. admin/en) for scoped translation files', () => {
     mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/admin/en.json']);
-    mockReadFile.mockImplementation(((path: string, opts?: any) => {
-      if (opts?.parse) return { key: 'value' };
-      return '{"key":"value"}';
-    }) as any);
+    mockGetCurrentTranslation.mockReturnValue({ key: 'value' });
     mockNormalizedGlob.mockReturnValue(['/tmp/i18n/admin/en.json']);
 
     compareKeysToFiles({
@@ -181,10 +174,7 @@ describe('compareKeysToFiles', () => {
 
   it('should unflatten translation before writing when unflat is true', () => {
     mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/en.json']);
-    mockReadFile.mockImplementation(((path: string, opts?: any) => {
-      if (opts?.parse) return {};
-      return '{}';
-    }) as any);
+    mockGetCurrentTranslation.mockReturnValue({});
     mockNormalizedGlob.mockReturnValue(['/tmp/i18n/en.json']);
 
     compareKeysToFiles({

--- a/libs/transloco-keys-manager/src/lib/webpack-plugin/generate-keys.ts
+++ b/libs/transloco-keys-manager/src/lib/webpack-plugin/generate-keys.ts
@@ -29,9 +29,11 @@ export function generateKeys({ translationPath, scopeToKeys, config }: Params) {
   const scopePaths = config.scopePathMap || {};
 
   const result = [];
+  const processedScopes = new Set<string>();
 
   for (const [scope, path] of Object.entries(scopePaths)) {
     const keys = scopeToKeys[scope];
+    processedScopes.add(scope);
     if (keys) {
       result.push({
         keys,
@@ -43,7 +45,7 @@ export function generateKeys({ translationPath, scopeToKeys, config }: Params) {
   }
 
   for (const [scope, keys] of Object.entries(scopeToKeys)) {
-    if (keys) {
+    if (keys && !processedScopes.has(scope)) {
       const isGlobal = scope === '__global';
 
       result.push({


### PR DESCRIPTION
<!--
Make sure the PR is structured as followed:
[docs/feat/fix/...](package): description
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Following a code review of `transloco-keys-manager`, several issues were found:

- `resolveScopeAlias` unconditionally stripped the last segment of a scope
  path assuming it was always a language, corrupting scope aliases whose
  path happened to end with a non-language segment.
- `createPot` merged flat extracted keys directly against the (potentially
  nested) current POT translation without unflattening first, producing
  incorrect merges when `unflat` is enabled.
- `addScope` could leave stale, non-bijective entries in the
  `scopeToAlias`/`aliasToScope` maps when a scope or alias was reassigned.
- `buildTable` and `compareKeysToFiles` called `process.exit()` directly,
  making them hard to test and preventing callers from controlling process
  termination.
- `compareKeysToFiles` and the Webpack plugin's `generateKeys` could process
  the same scope twice — once via `scopePathMap` and once via the default
  glob lookup — duplicating work and translation file writes.
- `marker`'s `params` argument was typed as `undefined`, so it couldn't
  accept the same interpolation params object used by `translate()`.
- A stray `await` on the (synchronous) `findMissingKeys` call in the CLI
  entrypoint triggered a `TS80007` compiler warning.

Issue Number: N/A

## What is the new behavior?

- `resolveScopeAlias` now checks the trailing scope path segment against the
  configured `langs` list before stripping it, only removing it when it is
  actually a known language.
- `createPot` unflattens the extracted translation before merging with the
  current nested translation when `unflat` is enabled, matching `createJson`'s
  behavior.
- `addScope` removes any previous reverse mapping before assigning a new
  scope/alias pair, keeping the two maps in sync.
- `buildTable` now returns `{ hasMissingKeys, hasExtraKeys }` and
  `compareKeysToFiles`/`findMissingKeys` propagate that result instead of
  exiting the process directly. The CLI (`src/index.ts`) now runs from an
  async `main()`, sets `process.exitCode` based on the result (1 for missing
  keys, 2 for extra keys), and catches/reports failures deterministically.
  The CLI also trims and filters empty entries from the comma-separated
  `--input` option and fails fast if none remain.
- `compareKeysToFiles` and `generateKeys` now track scopes already resolved
  via `scopePathMap` and skip them in the default-glob fallback loop,
  preventing duplicate processing.
- `marker`'s `params` parameter is now typed as `Record<string, unknown>`.
- Removed the unnecessary `await` on the synchronous `findMissingKeys` call.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- All 206 existing tests pass (`nx test transloco-keys-manager`), including
  updated unit tests for `buildTable` and `compareKeysToFiles` reflecting the
  new return-value-based (non-`process.exit`) API.
- `nx lint transloco-keys-manager` passes with 0 errors (pre-existing
  warnings only).
- `nx build transloco-keys-manager` succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved translation key detection with clear missing- and extra-key results.
  * Added support for translation parameters in marker usage.
  * Improved handling of unflattened translations and translation formats.
* **Bug Fixes**
  * Prevented duplicate scope processing and maintained consistent scope aliases.
  * Improved command-line path validation and error reporting.
  * Corrected language-scope resolution and translation file updates.
* **Tests**
  * Updated key comparison tests to validate returned status results and translation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->