### PR TITLE
fix(keys-manager): block prototype pollution in mergeDeep

### DIFF
--- a/libs/transloco-keys-manager/src/lib/tests/utils.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/utils.spec.ts
@@ -129,6 +129,22 @@ describe('object.utils', () => {
       const result = mergeDeep(target);
       expect(result).toBe(target);
     });
+
+    it('should not pollute Object.prototype when a source has a __proto__ key', async () => {
+      const { mergeDeep } = await import('../utils/object.utils');
+      // `readJsonSync` keeps `__proto__` as an own key on the parsed translation
+      const source = JSON.parse(
+        '{"__proto__": {"polluted": "yes"}, "prototype": "Prototyp", "hello": "Hallo"}',
+      );
+
+      const result = mergeDeep({}, source);
+
+      const polluted = ({} as any).polluted;
+      delete (Object.prototype as any).polluted;
+      expect(polluted).toBeUndefined();
+      // every other key, including one named `prototype`, still merges
+      expect(result).toEqual({ prototype: 'Prototyp', hello: 'Hallo' });
+    });
   });
 
   describe('stringify', () => {

--- a/libs/transloco-keys-manager/src/lib/utils/object.utils.ts
+++ b/libs/transloco-keys-manager/src/lib/utils/object.utils.ts
@@ -30,7 +30,10 @@ export function mergeDeep(target: object, ...sources: any[]) {
   const source = sources.shift();
 
   if (isObject(target) && isObject(source)) {
-    for (const key in source) {
+    for (const key of Object.keys(source)) {
+      // `target['__proto__']` reads through to `Object.prototype`, so merging a
+      // source key of that name writes translation data onto it.
+      if (key === '__proto__') continue;
       if (isObject(source[key])) {
         if (!target[key]) Object.assign(target, { [key]: {} });
         mergeDeep(target[key], source[key]);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #978

`mergeDeep` walks source keys with `for...in` and no key guard. When an existing translation file has an own `__proto__` key, `extract` reads it through `readJsonSync` (JSON.parse keeps `__proto__` as an own key) and hands it to `mergeDeep({}, translation, currentTranslation)`. On a plain object target, `target['__proto__']` resolves to `Object.prototype`, so the recursion writes the file's values onto it and every object in the CLI process inherits them.

I put the new spec on current master first and ran it against the unfixed code:

```
 FAIL  |transloco-keys-manager| src/lib/tests/utils.spec.ts > object.utils > mergeDeep > should not pollute Object.prototype when a source has a __proto__ key
AssertionError: expected 'yes' to be undefined
```

Then I built the package from master and drove the real write path, `getCurrentTranslation` followed by `createTranslation`, over a temp `en.json` of `{"__proto__": {"translocoPolluted": "yes"}, "prototype": "Prototyp", "hello": "Hallo"}`:

```
({}).translocoPolluted = "yes"
written en.json = { "prototype": "Prototyp", "hello": "Hallo" }
```

## What is the new behavior?

`mergeDeep` iterates `Object.keys(source)` and skips `__proto__`. That is the whole guard. A translation key named `prototype` or `constructor` merges exactly like it did before.

Same script, same file, against the fixed build:

```
({}).translocoPolluted = undefined
written en.json = { "prototype": "Prototyp", "hello": "Hallo" }
```

The written file is the same as what master wrote. `__proto__` never reached the output before this change either, it went onto `Object.prototype` instead of into the file, so nobody loses a key they had.

Using `Object.keys` instead of `for...in` also stops an already polluted prototype from leaking inherited keys into translation files.

One spec added next to the existing `mergeDeep` ones. It merges a parsed `__proto__` payload, asserts `({}).polluted` stays undefined, and asserts the sibling keys still come through.

```
> nx test transloco-keys-manager

 Test Files  19 passed (19)
      Tests  207 passed | 1 skipped (208)
```

`nx lint transloco-keys-manager` exits 0 and adds no new warnings, 53 before and 53 after.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I left `constructor` and `prototype` out of the guard on purpose. Neither is a pollution vector here: `target['prototype']` is undefined on a plain object, so that key just creates its own `{}` and recurses into it, and `target.constructor` is the `Object` function, which `isObject` rejects, so the recursion stops. Denying them would delete real translation keys from users' files. A `constructor` key holding an object is still dropped, exactly as it was before this change.

Fixes #978


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep-merge safety by preventing malicious prototype pollution through specially crafted `__proto__` keys.
  * Preserved normal merging behavior for supported properties, including `prototype`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->