### PR TITLE
feat(transloco): v9 deprecation removal, ng update migration and keys-manager Angular 20+ support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
   # keys-manager's peer ranges are far wider than the versions the workspace
   # pins, and Angular 21.1 reshaped template AST nodes its extractors read.
   keys-manager-compat:
+    # Checks out and runs pull-request code; the steps below only ever read the
+    # repository, so the token is narrowed to match.
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,45 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # keys-manager's peer ranges are far wider than the versions the workspace
+  # pins, and Angular 21.1 reshaped template AST nodes its extractors read.
+  keys-manager-compat:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Oldest supported: flat @switch cases, and compiler-cli@20.0.x caps ts below 5.9.
+          - angular: '20'
+            typescript: '5.8'
+          # Last minor before the AST reshape.
+          - angular: '21.0'
+            typescript: '5.9'
+          - angular: '21'
+            typescript: '5.9'
+          # Newest supported; Angular 22 requires ts 6.0.
+          - angular: '22'
+            typescript: '6.0'
+    runs-on: ubuntu-latest
+    name: keys-manager ng${{ matrix.angular }} ts${{ matrix.typescript }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup
+        uses: ./.github/actions/step-setup
+
+      - name: Build keys-manager
+        run: npx nx build transloco-keys-manager
+        shell: bash
+
+      - name: Verify key extraction
+        run: |
+          node tools/scripts/verify-keys-manager-compat.mts \
+            --angular=${{ matrix.angular }} \
+            --typescript=${{ matrix.typescript }}
+        shell: bash
+
   commitlint:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
@@ -102,6 +141,7 @@ jobs:
     if: always()
     needs:
       - ci-step
+      - keys-manager-compat
       - commitlint
       - actionlint
     runs-on: ubuntu-latest

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -28,7 +28,7 @@ nx migrate @jsverse/transloco  # Nx
 - The package moved into the main repo and joined the shared version line, so it jumps from `8.1.1` to `9.0.0`.
 - `@angular/compiler` peer dependency is now `>=v20` and `typescript` is now `>=5.8`.
 
-## Transloco Optimize, Scoped Libs, Utils & Validator
+## Transloco Keys Manager, Optimize, Scoped Libs, Utils & Validator
 
 - Node.js `>=22` is now required.
 - Transloco Scoped Libs bumped `chokidar` to v5, which is ESM-only.

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,3 +1,38 @@
+# Transloco v9
+
+Most of the changes below are applied automatically:
+
+```bash
+ng update @jsverse/transloco   # Angular CLI
+nx migrate @jsverse/transloco  # Nx
+```
+
+## Transloco
+
+- Removed the deprecated `translocoRead` input, use `translocoPrefix` instead. In the structural form the `read` microsyntax key becomes `prefix`.
+- `translate()` and `translateObject()` now require `provideGlobalTranslateFn()` in the providers. Without it they return `''` / `[]` and warn in dev mode. Omit it in SSR and multi-instance MFE setups.
+- `@angular/core` peer dependency is now `>=v20`.
+- `rxjs` peer dependency is now `^6.5.3 || ^7.4.0`.
+
+## Transloco Locale & Messageformat
+
+- `@angular/core` peer dependency is now `>=v20`.
+- `rxjs` peer dependency is now `^6.5.3 || ^7.4.0`.
+
+## Transloco Persist Lang, Persist Translations & Preload Langs
+
+- `@angular/core` peer dependency is now `>=v20`.
+
+## Transloco Keys Manager
+
+- The package moved into the main repo and joined the shared version line, so it jumps from `8.1.1` to `9.0.0`.
+- `@angular/compiler` peer dependency is now `>=v20` and `typescript` is now `>=5.8`.
+
+## Transloco Optimize, Scoped Libs, Utils & Validator
+
+- Node.js `>=22` is now required.
+- Transloco Scoped Libs bumped `chokidar` to v5, which is ESM-only.
+
 # Transloco v8
 
 ## Transloco

--- a/libs/transloco-keys-manager/package.json
+++ b/libs/transloco-keys-manager/package.json
@@ -46,8 +46,8 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@angular/compiler": ">= 21.1.0 < 23.0.0",
-    "typescript": ">= 5.9.0 < 7.0.0"
+    "@angular/compiler": ">= 20.0.0 < 23.0.0",
+    "typescript": ">= 5.8.0 < 7.0.0"
   },
   "dependencies": {
     "@jsverse/angular-utils": "1.0.0-beta.6",

--- a/libs/transloco-keys-manager/src/lib/keys-builder/template/compiler-compat.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/template/compiler-compat.ts
@@ -1,0 +1,65 @@
+/**
+ * Shims for the two template AST shapes Angular 21.1 changed, so the extractors
+ * can be written against one shape across the supported `@angular/compiler`
+ * range.
+ *
+ * Namespace import, not named: a named import of a symbol missing from the
+ * installed version is `undefined`, and `x instanceof undefined` throws.
+ */
+import * as compiler from '@angular/compiler';
+import type {
+  LiteralMapKey,
+  LiteralMapPropertyKey,
+  TmplAstNode,
+  TmplAstSwitchBlock,
+} from '@angular/compiler';
+
+/**
+ * Structural on purpose: naming the 21.1-only `TmplAstSwitchBlockCaseGroup`
+ * would put a symbol in the emitted `.d.ts` that Angular 20's typings lack.
+ */
+export type SwitchCaseChildrenOwner = TmplAstNode & {
+  children: TmplAstNode[];
+};
+
+/** Added in 21.1; `undefined` on 20.x-21.0. */
+const SwitchBlockCaseGroup = (compiler as Partial<typeof compiler>)
+  .TmplAstSwitchBlockCaseGroup;
+
+const SwitchBlockCase = compiler.TmplAstSwitchBlockCase;
+
+/** Pre-21.1 `@switch`, which listed cases flat instead of grouping them. */
+interface LegacySwitchBlock {
+  cases: TmplAstNode[];
+}
+
+/**
+ * 21.1 moved `children` off `@case` and onto the new group node, so which class
+ * owns them depends on the installed version.
+ */
+export function isSwitchCaseChildrenOwner(
+  node: unknown,
+): node is { children: TmplAstNode[] } {
+  return SwitchBlockCaseGroup
+    ? node instanceof SwitchBlockCaseGroup
+    : node instanceof SwitchBlockCase;
+}
+
+export function resolveSwitchBlockChildren(
+  node: TmplAstSwitchBlock,
+): TmplAstNode[] {
+  const groups = (node as Partial<TmplAstSwitchBlock>).groups;
+
+  return groups ?? (node as unknown as LegacySwitchBlock).cases ?? [];
+}
+
+/**
+ * 21.1 tagged `LiteralMapKey` with `kind` to make room for spread keys. Before
+ * that every key was a property key, so a missing discriminant means `true` -
+ * testing `kind === 'property'` alone drops every key on Angular 20.
+ */
+export function isLiteralMapPropertyKey(
+  key: LiteralMapKey,
+): key is LiteralMapPropertyKey {
+  return 'kind' in key ? key.kind === 'property' : true;
+}

--- a/libs/transloco-keys-manager/src/lib/keys-builder/template/compiler-compat.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/template/compiler-compat.ts
@@ -9,10 +9,16 @@
 import * as compiler from '@angular/compiler';
 import type {
   LiteralMapKey,
-  LiteralMapPropertyKey,
   TmplAstNode,
   TmplAstSwitchBlock,
 } from '@angular/compiler';
+
+/**
+ * Structural on purpose, for the same reason as `SwitchCaseChildrenOwner`
+ * below: `LiteralMapPropertyKey` only exists from Angular 21.1, so naming it
+ * would put a symbol in the emitted `.d.ts` that Angular 20's typings lack.
+ */
+type LiteralMapPropertyKey = LiteralMapKey & { key: string };
 
 /**
  * Structural on purpose: naming the 21.1-only `TmplAstSwitchBlockCaseGroup`

--- a/libs/transloco-keys-manager/src/lib/keys-builder/template/utils.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/template/utils.ts
@@ -178,10 +178,16 @@ export function resolveBlockChildNodes(node: BlockNode): TmplAstNode[] {
 
 export function resolveKeysFromLiteralMap(node: LiteralMap): string[] {
   let keys: string[] = [];
-  const propertyKeys = node.keys.filter(isLiteralMapPropertyKey);
 
-  for (let i = 0; i < node.values.length; i++) {
-    const { key } = propertyKeys[i];
+  // `keys` and `values` are parallel arrays, and a spread key owns an entry in
+  // both - so the walk skips over the keys it cannot name rather than filtering
+  // them out, which would shift every later value onto the wrong key and run
+  // off the end of the shortened list.
+  for (let i = 0; i < node.keys.length; i++) {
+    const mapKey = node.keys[i];
+    if (!isLiteralMapPropertyKey(mapKey)) continue;
+
+    const { key } = mapKey;
     const value = node.values[i];
 
     if (isLiteralMap(value)) {

--- a/libs/transloco-keys-manager/src/lib/keys-builder/template/utils.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/template/utils.ts
@@ -2,8 +2,6 @@ import {
   Call,
   Interpolation,
   LiteralMap,
-  LiteralMapKey,
-  LiteralMapPropertyKey,
   parseTemplate as ngParseTemplate,
   ParseTemplateOptions,
   PropertyRead,
@@ -20,7 +18,6 @@ import {
   TmplAstIfBlockBranch,
   TmplAstNode,
   TmplAstSwitchBlock,
-  TmplAstSwitchBlockCaseGroup,
   TmplAstTemplate,
   TmplAstTextAttribute,
 } from '@angular/compiler';
@@ -29,6 +26,14 @@ import { isLiteralMap } from '@jsverse/angular-utils';
 import { readFile } from '../../utils/file.utils';
 
 import { TemplateExtractorConfig } from './types';
+import {
+  isLiteralMapPropertyKey,
+  isSwitchCaseChildrenOwner,
+  resolveSwitchBlockChildren,
+  SwitchCaseChildrenOwner,
+} from './compiler-compat';
+
+export { isLiteralMapPropertyKey } from './compiler-compat';
 
 export function isTemplate(node: unknown): node is TmplAstTemplate {
   return node instanceof TmplAstTemplate;
@@ -48,12 +53,6 @@ export function isBoundAttribute(node: unknown): node is TmplAstBoundAttribute {
 
 export function isTextAttribute(node: unknown): node is TmplAstTextAttribute {
   return node instanceof TmplAstTextAttribute;
-}
-
-export function isLiteralMapPropertyKey(
-  key: LiteralMapKey,
-): key is LiteralMapPropertyKey {
-  return key.kind === 'property';
 }
 
 export function isInterpolation(ast: unknown): ast is Interpolation {
@@ -101,7 +100,7 @@ type BlockNode =
   | TmplAstDeferredBlockPlaceholder
   | TmplAstForLoopBlockEmpty
   | TmplAstIfBlockBranch
-  | TmplAstSwitchBlockCaseGroup
+  | SwitchCaseChildrenOwner
   | TmplAstForLoopBlock
   | TmplAstDeferredBlock
   | TmplAstIfBlock
@@ -116,7 +115,7 @@ export function isBlockWithChildren(
     node instanceof TmplAstDeferredBlockPlaceholder ||
     node instanceof TmplAstForLoopBlockEmpty ||
     node instanceof TmplAstIfBlockBranch ||
-    node instanceof TmplAstSwitchBlockCaseGroup
+    isSwitchCaseChildrenOwner(node)
   );
 }
 
@@ -140,12 +139,6 @@ export function isTmplAstSwitchBlock(
   node: unknown,
 ): node is TmplAstSwitchBlock {
   return node instanceof TmplAstSwitchBlock;
-}
-
-export function isTmplAstSwitchBlockCaseGroup(
-  node: unknown,
-): node is TmplAstSwitchBlockCaseGroup {
-  return node instanceof TmplAstSwitchBlockCaseGroup;
 }
 
 export function isBlockNode(node: TmplAstNode): node is BlockNode {
@@ -177,11 +170,7 @@ export function resolveBlockChildNodes(node: BlockNode): TmplAstNode[] {
   }
 
   if (isTmplAstSwitchBlock(node)) {
-    return node.groups;
-  }
-
-  if (isTmplAstSwitchBlockCaseGroup(node)) {
-    return node.children;
+    return resolveSwitchBlockChildren(node);
   }
 
   return node.children;

--- a/libs/transloco-keys-manager/src/lib/tests/compiler-compat.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/compiler-compat.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { TmplAstSwitchBlock, parseTemplate } from '@angular/compiler';
+import type {
+  ASTWithSource,
+  BindingPipe,
+  LiteralMap,
+  TmplAstElement,
+} from '@angular/compiler';
 
 import {
   isLiteralMapPropertyKey,
@@ -10,6 +16,7 @@ import {
   isBlockNode,
   isBlockWithChildren,
   resolveBlockChildNodes,
+  resolveKeysFromLiteralMap,
 } from '../keys-builder/template/utils';
 
 /**
@@ -135,5 +142,52 @@ describe('compiler-compat: literal map keys', () => {
       WHEN it is classified
       THEN it is rejected`, () => {
     expect(isLiteralMapPropertyKey({ kind: 'spread' } as never)).toBe(false);
+  });
+});
+
+describe('resolveKeysFromLiteralMap: spread keys', () => {
+  /** The params literal of `'greeting' | transloco: <params>`, as parsed. */
+  function parseParams(params: string): LiteralMap {
+    const { nodes, errors } = parseTemplate(
+      `<a [title]="'greeting' | transloco: ${params}"></a>`,
+      'test.html',
+    );
+
+    expect(errors ?? []).toEqual([]);
+
+    const element = nodes[0] as TmplAstElement;
+    const pipe = (element.inputs[0].value as ASTWithSource).ast as BindingPipe;
+
+    return pipe.args[0] as LiteralMap;
+  }
+
+  it(`GIVEN params holding a spread ahead of a named key
+      WHEN the keys are resolved
+      THEN the named key is returned rather than the walk throwing`, () => {
+    // `keys` and `values` stay parallel across a spread, so filtering the
+    // spread out of `keys` alone used to run the index off the end.
+    expect(
+      resolveKeysFromLiteralMap(parseParams(`{ ...params, name: 'x' }`)),
+    ).toEqual(['name']);
+  });
+
+  it(`GIVEN params holding a spread between two named keys
+      WHEN the keys are resolved
+      THEN each key keeps its own value`, () => {
+    // The desync is silent rather than fatal here: `b` would have been paired
+    // with the nested map that belongs to `c`.
+    expect(
+      resolveKeysFromLiteralMap(
+        parseParams(`{ a: 1, ...params, b: 2, c: { d: 3 } }`),
+      ),
+    ).toEqual(['a', 'b', 'c.d']);
+  });
+
+  it(`GIVEN params holding a spread last
+      WHEN the keys are resolved
+      THEN the named keys are returned`, () => {
+    expect(
+      resolveKeysFromLiteralMap(parseParams(`{ name: 'x', ...params }`)),
+    ).toEqual(['name']);
   });
 });

--- a/libs/transloco-keys-manager/src/lib/tests/compiler-compat.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/compiler-compat.spec.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { TmplAstSwitchBlock, parseTemplate } from '@angular/compiler';
+
+import {
+  isLiteralMapPropertyKey,
+  isSwitchCaseChildrenOwner,
+  resolveSwitchBlockChildren,
+} from '../keys-builder/template/compiler-compat';
+import {
+  isBlockNode,
+  isBlockWithChildren,
+  resolveBlockChildNodes,
+} from '../keys-builder/template/utils';
+
+/**
+ * Only one `@angular/compiler` is ever installed, so the pre-21.1 shapes are
+ * built by hand here - see `keys-builder/template/compiler-compat.ts`. The
+ * `keys-manager-compat` CI job covers the real versions end to end.
+ */
+
+/**
+ * A real `TmplAstSwitchBlock` (so `instanceof` holds) in the pre-21.1 shape:
+ * cases listed flat, no `groups`.
+ */
+function createLegacySwitchBlock(cases: unknown[]): TmplAstSwitchBlock {
+  const node = Object.create(
+    TmplAstSwitchBlock.prototype,
+  ) as TmplAstSwitchBlock;
+
+  Object.assign(node, { cases });
+
+  return node;
+}
+
+describe('compiler-compat: switch block shape', () => {
+  it(`GIVEN a switch block using the pre-21.1 flat cases shape
+      WHEN its children are resolved
+      THEN the cases are returned`, () => {
+    const caseA = { children: [] };
+    const caseB = { children: [] };
+
+    expect(
+      resolveSwitchBlockChildren(createLegacySwitchBlock([caseA, caseB])),
+    ).toEqual([caseA, caseB]);
+  });
+
+  it(`GIVEN a switch block using the 21.1 grouped shape
+      WHEN its children are resolved
+      THEN the groups are returned`, () => {
+    const group = { children: [] };
+    const node = Object.create(
+      TmplAstSwitchBlock.prototype,
+    ) as TmplAstSwitchBlock;
+    Object.assign(node, { groups: [group] });
+
+    expect(resolveSwitchBlockChildren(node)).toEqual([group]);
+  });
+
+  it(`GIVEN a switch block carrying neither shape
+      WHEN its children are resolved
+      THEN an empty list is returned rather than undefined`, () => {
+    const node = Object.create(
+      TmplAstSwitchBlock.prototype,
+    ) as TmplAstSwitchBlock;
+
+    expect(resolveSwitchBlockChildren(node)).toEqual([]);
+  });
+
+  it(`GIVEN a legacy switch block reached through the generic block walker
+      WHEN its child nodes are resolved
+      THEN the flat cases are still returned`, () => {
+    const caseA = { children: [] };
+    const node = createLegacySwitchBlock([caseA]);
+
+    expect(isBlockNode(node)).toBe(true);
+    expect(resolveBlockChildNodes(node)).toEqual([caseA]);
+  });
+});
+
+describe('compiler-compat: switch case children owner', () => {
+  it(`GIVEN a template using @switch
+      WHEN the parsed tree is walked
+      THEN the node owning the case children is recognised`, () => {
+    // Checks the detection against the real AST rather than a stub.
+    const { nodes } = parseTemplate(
+      '@switch (cond) { @case (a) { <p>{{ t("x") }}</p> } }',
+      'test.html',
+    );
+    const switchBlock = nodes.find(
+      (node) => node instanceof TmplAstSwitchBlock,
+    );
+
+    expect(switchBlock).toBeDefined();
+
+    const children = resolveSwitchBlockChildren(
+      switchBlock as TmplAstSwitchBlock,
+    );
+
+    expect(children.length).toBeGreaterThan(0);
+    expect(children.every(isSwitchCaseChildrenOwner)).toBe(true);
+    expect(children.every(isBlockWithChildren)).toBe(true);
+  });
+
+  it(`GIVEN a plain object
+      WHEN it is tested for being a switch case children owner
+      THEN it is rejected without throwing`, () => {
+    // On Angular 20 the group class is undefined, and `x instanceof undefined`
+    // throws rather than returning false.
+    expect(() => isSwitchCaseChildrenOwner({ children: [] })).not.toThrow();
+    expect(isSwitchCaseChildrenOwner({ children: [] })).toBe(false);
+    expect(isSwitchCaseChildrenOwner(null)).toBe(false);
+  });
+});
+
+describe('compiler-compat: literal map keys', () => {
+  it(`GIVEN a pre-21.1 literal map key with no kind discriminant
+      WHEN it is classified
+      THEN it counts as a property key`, () => {
+    // Testing `kind === 'property'` alone empties the filter on Angular 20, and
+    // `resolveKeysFromLiteralMap` then throws destructuring `propertyKeys[i]`.
+    expect(isLiteralMapPropertyKey({ key: 'a', quoted: false } as never)).toBe(
+      true,
+    );
+  });
+
+  it(`GIVEN a 21.1 property key
+      WHEN it is classified
+      THEN it counts as a property key`, () => {
+    expect(
+      isLiteralMapPropertyKey({ kind: 'property', key: 'a' } as never),
+    ).toBe(true);
+  });
+
+  it(`GIVEN a 21.1 spread key
+      WHEN it is classified
+      THEN it is rejected`, () => {
+    expect(isLiteralMapPropertyKey({ kind: 'spread' } as never)).toBe(false);
+  });
+});

--- a/libs/transloco-keys-manager/v9.md
+++ b/libs/transloco-keys-manager/v9.md
@@ -121,6 +121,10 @@ deciding whether translator notes deserve an explicit mechanism instead of a mag
 
 ## 3. Hard-error on CLI flags the command does not support
 
+> **Status: deferred to v10.** v9 ships the 8.x warning unchanged - unsupported flags are still
+> accepted-and-ignored and the run exits zero. The non-zero exit lands in v10. The proposal below
+> stands as written; only the target release moved.
+
 ### Current behaviour
 
 `optionDefinitions` is one flat list shared by both commands, and `src/index.ts` parses it once before

--- a/libs/transloco/migrations/migration.json
+++ b/libs/transloco/migrations/migration.json
@@ -2,6 +2,7 @@
   "schematics": {
     "migration-v9": {
       "version": "9.0.0",
+      "requires": { "@angular/core": ">=20.0.0" },
       "description": "Migrates a Transloco v8 workspace to v9: replaces the removed `translocoRead` input with `translocoPrefix`, adds `provideGlobalTranslateFn()` where the standalone `translate()`/`translateObject()` functions are used, and reports the breaking changes that cannot be fixed automatically.",
       "factory": "./v9/index#migrateToV9"
     }

--- a/libs/transloco/migrations/migration.json
+++ b/libs/transloco/migrations/migration.json
@@ -1,0 +1,9 @@
+{
+  "schematics": {
+    "migration-v9": {
+      "version": "9.0.0",
+      "description": "Migrates a Transloco v8 workspace to v9: replaces the removed `translocoRead` input with `translocoPrefix`, adds `provideGlobalTranslateFn()` where the standalone `translate()`/`translateObject()` functions are used, and reports the breaking changes that cannot be fixed automatically.",
+      "factory": "./v9/index#migrateToV9"
+    }
+  }
+}

--- a/libs/transloco/migrations/package.json
+++ b/libs/transloco/migrations/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/libs/transloco/migrations/v9/global-translate-fn.ts
+++ b/libs/transloco/migrations/v9/global-translate-fn.ts
@@ -4,37 +4,147 @@ import {
   Tree,
   chain,
 } from '@angular-devkit/schematics';
-import { addRootProvider } from '@schematics/angular/utility/standalone/rules';
-import { getMainFilePath } from '@schematics/angular/utility/standalone/util';
 
+import { loadStandaloneRules, loadTypeScript } from './lazy-deps';
 import { collectFiles, getProjects } from './workspace-utils';
 
-const TRANSLOCO_IMPORT =
-  /import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"]@jsverse\/transloco['"]/g;
+const TRANSLOCO_PACKAGE = '@jsverse/transloco';
 
 /** The standalone functions that stopped being auto-wired in v9. */
 const GLOBAL_FNS = ['translate', 'translateObject'];
 
 /**
- * Matches on import specifiers rather than call sites, so a local helper named
- * `translate` isn't mistaken for the global one.
+ * Whether `source` reaches for `translate()`/`translateObject()` at runtime.
+ *
+ * Detection is anchored on the import rather than on call sites, so a local
+ * helper that happens to be named `translate` is not mistaken for the global
+ * one. Reading the import declarations from the AST rather than by pattern is
+ * what lets `import type { translate }` be recognised for what it is: erased
+ * before the app ever runs, so it needs no provider.
  */
 export function usesGlobalTranslateFn(source: string): boolean {
-  TRANSLOCO_IMPORT.lastIndex = 0;
-  let match: RegExpExecArray | null;
+  const ts = loadTypeScript();
+  if (!ts) return false;
 
-  while ((match = TRANSLOCO_IMPORT.exec(source)) !== null) {
-    const imported = match[1].split(',').map((specifier) =>
-      specifier
-        .trim()
-        .split(/\s+as\s+/)[0]
-        .trim(),
+  const file = ts.createSourceFile(
+    'transloco-usage.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  for (const statement of file.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== TRANSLOCO_PACKAGE
+    )
+      continue;
+
+    // `import type { ... }` disappears at compile time, so it is not usage.
+    const clause = statement.importClause;
+    if (!clause || clause.isTypeOnly || !clause.namedBindings) continue;
+
+    const bindings = clause.namedBindings;
+
+    // `import * as transloco` only counts if the namespace is actually called.
+    if (ts.isNamespaceImport(bindings)) {
+      if (callsNamespacedGlobalFn(file, bindings.name.text, ts)) return true;
+
+      continue;
+    }
+
+    const imports = bindings.elements.some(
+      (element) =>
+        !element.isTypeOnly &&
+        GLOBAL_FNS.includes((element.propertyName ?? element.name).text),
     );
 
-    if (imported.some((name) => GLOBAL_FNS.includes(name))) return true;
+    if (imports) return true;
   }
 
   return false;
+}
+
+const PROVIDER_FN = 'provideGlobalTranslateFn';
+
+/**
+ * Whether `source` actually calls `provideGlobalTranslateFn()`.
+ *
+ * The check is on a call expression rather than on the text, so a mention in a
+ * comment, a doc string or an unrelated identifier cannot make the migration
+ * believe a project is already wired and skip it. Any call counts, wherever it
+ * lives: extracting providers into their own file and spreading them into
+ * `app.config.ts` is a normal thing to do.
+ */
+export function providesGlobalTranslateFn(source: string): boolean {
+  const ts = loadTypeScript();
+  if (!ts) return false;
+
+  const file = ts.createSourceFile(
+    'transloco-providers.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  let found = false;
+
+  const visit = (node: import('typescript').Node): void => {
+    if (found) return;
+
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      const name = ts.isIdentifier(callee)
+        ? callee.text
+        : ts.isPropertyAccessExpression(callee)
+          ? callee.name.text
+          : undefined;
+
+      if (name === PROVIDER_FN) {
+        found = true;
+
+        return;
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(file, visit);
+
+  return found;
+}
+
+/** Whether `namespace.translate(...)` or `.translateObject(...)` is called. */
+function callsNamespacedGlobalFn(
+  file: import('typescript').SourceFile,
+  namespace: string,
+  ts: NonNullable<ReturnType<typeof loadTypeScript>>,
+): boolean {
+  let found = false;
+
+  const visit = (node: import('typescript').Node): void => {
+    if (found) return;
+
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === namespace &&
+      GLOBAL_FNS.includes(node.expression.name.text)
+    ) {
+      found = true;
+
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(file, visit);
+
+  return found;
 }
 
 /**
@@ -58,6 +168,18 @@ export function addGlobalTranslateFn(): Rule {
       return;
     }
 
+    // Only ships with `@angular/cli` or `@nx/angular`. Without it the provider
+    // cannot be wired, but the template rewrite has already run and stands.
+    const standalone = loadStandaloneRules();
+    if (!standalone) {
+      context.logger.warn(
+        `  ↳ @schematics/angular is not installed, so provideGlobalTranslateFn() could not\n` +
+          `    be added automatically. Add it to your application providers by hand.`,
+      );
+
+      return;
+    }
+
     const rules: Rule[] = [];
     const librariesWithUsage: string[] = [];
     const unresolved: string[] = [];
@@ -70,11 +192,10 @@ export function addGlobalTranslateFn(): Rule {
 
       if (!contents.some(usesGlobalTranslateFn)) continue;
 
-      // Already migrated - either by a previous run or by hand.
-      if (
-        contents.some((source) => source.includes('provideGlobalTranslateFn'))
-      )
-        continue;
+      // Already wired - by a previous run or by hand. The guard has to stay:
+      // `addRootProvider` inserts unconditionally, with no duplicate check of
+      // its own, so a second run would add a second call.
+      if (contents.some(providesGlobalTranslateFn)) continue;
 
       if (!project.isApplication) {
         librariesWithUsage.push(project.name);
@@ -85,17 +206,17 @@ export function addGlobalTranslateFn(): Rule {
       // executors - can't be wired. Skip it rather than aborting the migration,
       // which would roll back the template rewrites too.
       try {
-        await getMainFilePath(tree, project.name);
+        await standalone.getMainFilePath(tree, project.name);
       } catch {
         unresolved.push(project.name);
         continue;
       }
 
       rules.push(
-        addRootProvider(
+        standalone.addRootProvider(
           project.name,
           ({ code, external }) =>
-            code`${external('provideGlobalTranslateFn', '@jsverse/transloco')}()`,
+            code`${external(PROVIDER_FN, TRANSLOCO_PACKAGE)}()`,
         ),
       );
       context.logger.info(
@@ -137,8 +258,7 @@ function reportUnwiredUsage(tree: Tree, context: SchematicContext) {
     .map((path) => [path, tree.read(path)?.toString() ?? ''] as const)
     .filter(([, source]) => source.includes('@jsverse/transloco'));
 
-  if (sources.some(([, source]) => source.includes('provideGlobalTranslateFn')))
-    return;
+  if (sources.some(([, source]) => providesGlobalTranslateFn(source))) return;
 
   const users = sources
     .filter(([, source]) => usesGlobalTranslateFn(source))

--- a/libs/transloco/migrations/v9/global-translate-fn.ts
+++ b/libs/transloco/migrations/v9/global-translate-fn.ts
@@ -1,0 +1,159 @@
+import {
+  Rule,
+  SchematicContext,
+  Tree,
+  chain,
+} from '@angular-devkit/schematics';
+import { addRootProvider } from '@schematics/angular/utility/standalone/rules';
+import { getMainFilePath } from '@schematics/angular/utility/standalone/util';
+
+import { collectFiles, getProjects } from './workspace-utils';
+
+const TRANSLOCO_IMPORT =
+  /import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"]@jsverse\/transloco['"]/g;
+
+/** The standalone functions that stopped being auto-wired in v9. */
+const GLOBAL_FNS = ['translate', 'translateObject'];
+
+/**
+ * Matches on import specifiers rather than call sites, so a local helper named
+ * `translate` isn't mistaken for the global one.
+ */
+export function usesGlobalTranslateFn(source: string): boolean {
+  TRANSLOCO_IMPORT.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = TRANSLOCO_IMPORT.exec(source)) !== null) {
+    const imported = match[1].split(',').map((specifier) =>
+      specifier
+        .trim()
+        .split(/\s+as\s+/)[0]
+        .trim(),
+    );
+
+    if (imported.some((name) => GLOBAL_FNS.includes(name))) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Adds `provideGlobalTranslateFn()` to applications that use the standalone
+ * functions, restoring the wiring v8 did implicitly. Projects that don't import
+ * them are skipped, preserving the SSR/MFE opt-out.
+ *
+ * Works in Nx workspaces too: `nx migrate` reads the same `ng-update` key, and
+ * Nx's CLI adapter serves a virtual `angular.json` built from the project
+ * graph, which is what Angular's own migrations rely on as well.
+ */
+export function addGlobalTranslateFn(): Rule {
+  return async (tree: Tree, context: SchematicContext) => {
+    const projects = getProjects(tree);
+
+    // Neither a real nor a virtual workspace - a bare library, or an Nx repo
+    // without the Angular plugin. `addRootProvider` needs a registered project.
+    if (!projects.length) {
+      reportUnwiredUsage(tree, context);
+
+      return;
+    }
+
+    const rules: Rule[] = [];
+    const librariesWithUsage: string[] = [];
+    const unresolved: string[] = [];
+
+    for (const project of projects) {
+      const sources = collectFiles(tree, project.sourceRoot, ['.ts']);
+      const contents = sources
+        .map((path) => tree.read(path)?.toString() ?? '')
+        .filter((source) => source.includes('@jsverse/transloco'));
+
+      if (!contents.some(usesGlobalTranslateFn)) continue;
+
+      // Already migrated - either by a previous run or by hand.
+      if (
+        contents.some((source) => source.includes('provideGlobalTranslateFn'))
+      )
+        continue;
+
+      if (!project.isApplication) {
+        librariesWithUsage.push(project.name);
+        continue;
+      }
+
+      // A project whose builder exposes no entry point - possible for some Nx
+      // executors - can't be wired. Skip it rather than aborting the migration,
+      // which would roll back the template rewrites too.
+      try {
+        await getMainFilePath(tree, project.name);
+      } catch {
+        unresolved.push(project.name);
+        continue;
+      }
+
+      rules.push(
+        addRootProvider(
+          project.name,
+          ({ code, external }) =>
+            code`${external('provideGlobalTranslateFn', '@jsverse/transloco')}()`,
+        ),
+      );
+      context.logger.info(
+        `  ↳ Added provideGlobalTranslateFn() to "${project.name}".`,
+      );
+    }
+
+    if (unresolved.length) {
+      context.logger.warn(
+        `  ↳ Could not find an entry point for: ${unresolved.join(', ')}.\n` +
+          `    Add provideGlobalTranslateFn() to their providers by hand.`,
+      );
+    }
+
+    if (librariesWithUsage.length) {
+      context.logger.warn(
+        `  ↳ The following libraries use translate()/translateObject(): ${librariesWithUsage.join(
+          ', ',
+        )}.\n` +
+          `    Libraries cannot provide it themselves - the consuming application must call\n` +
+          `    provideGlobalTranslateFn() for these functions to keep working.`,
+      );
+    }
+
+    return chain(rules);
+  };
+}
+
+/** How many offending files to name before collapsing the rest into a count. */
+const MAX_REPORTED_FILES = 10;
+
+/**
+ * Names the files that need `provideGlobalTranslateFn()` when it can't be added
+ * for them. Stays quiet if the provider already appears somewhere in the tree,
+ * since it is usually declared far from the call sites.
+ */
+function reportUnwiredUsage(tree: Tree, context: SchematicContext) {
+  const sources = collectFiles(tree, '', ['.ts'])
+    .map((path) => [path, tree.read(path)?.toString() ?? ''] as const)
+    .filter(([, source]) => source.includes('@jsverse/transloco'));
+
+  if (sources.some(([, source]) => source.includes('provideGlobalTranslateFn')))
+    return;
+
+  const users = sources
+    .filter(([, source]) => usesGlobalTranslateFn(source))
+    .map(([path]) => path);
+
+  if (!users.length) return;
+
+  const shown = users.slice(0, MAX_REPORTED_FILES);
+  const rest = users.length - shown.length;
+
+  context.logger.warn(
+    `  ↳ No Angular workspace file found, so provideGlobalTranslateFn() could not be\n` +
+      `    added automatically. Add it to your application providers - without it the\n` +
+      `    following files get '' / [] back from translate()/translateObject():\n` +
+      shown.map((path) => `      ${path}`).join('\n') +
+      (rest > 0 ? `\n      ...and ${rest} more` : ''),
+  );
+}

--- a/libs/transloco/migrations/v9/index.ts
+++ b/libs/transloco/migrations/v9/index.ts
@@ -1,0 +1,81 @@
+import {
+  Rule,
+  SchematicContext,
+  Tree,
+  chain,
+} from '@angular-devkit/schematics';
+
+import { migrateInlineTemplates, migrateTemplate } from './template-utils';
+import { collectFiles } from './workspace-utils';
+import { addGlobalTranslateFn } from './global-translate-fn';
+import { reportVersionFloors } from './report-version-floors';
+
+/**
+ * Replaces `translocoRead` with `translocoPrefix`. Walks the whole tree rather
+ * than per project - templates need not belong to a workspace project.
+ */
+function migrateTranslocoRead(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    let renamed = 0;
+    let removed = 0;
+    let skipped = 0;
+
+    // One walk for both extensions; visiting the tree is the expensive part.
+    for (const path of collectFiles(tree, '', ['.html', '.ts'])) {
+      const source = tree.read(path)?.toString();
+      if (!source) continue;
+
+      if (path.endsWith('.html')) {
+        const result = migrateTemplate(source);
+        if (!result) continue;
+
+        tree.overwrite(path, result.content);
+        renamed += result.renamed;
+        removed += result.removed;
+        continue;
+      }
+
+      const result = migrateInlineTemplates(source);
+      if (!result) continue;
+
+      if (result.content !== source) tree.overwrite(path, result.content);
+      renamed += result.renamed;
+      removed += result.removed;
+
+      if (result.skipped) {
+        skipped += result.skipped;
+        context.logger.warn(
+          `  ↳ Could not parse an inline template in ${path}. Rename translocoRead to translocoPrefix by hand.`,
+        );
+      }
+    }
+
+    if (renamed) {
+      context.logger.info(
+        `  ↳ Renamed ${renamed} translocoRead binding(s) to translocoPrefix.`,
+      );
+    }
+
+    if (removed) {
+      context.logger.info(
+        `  ↳ Removed ${removed} redundant translocoRead binding(s) from elements that already had translocoPrefix.`,
+      );
+    }
+
+    if (!renamed && !removed && !skipped) {
+      context.logger.info('  ↳ No translocoRead usages found.');
+    }
+  };
+}
+
+export function migrateToV9(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    context.logger.info('Migrating your workspace to Transloco v9...');
+
+    return chain([
+      migrateTranslocoRead(),
+      addGlobalTranslateFn(),
+      reportVersionFloors(),
+    ])(tree, context);
+  };
+}

--- a/libs/transloco/migrations/v9/index.ts
+++ b/libs/transloco/migrations/v9/index.ts
@@ -19,33 +19,37 @@ function migrateTranslocoRead(): Rule {
     let renamed = 0;
     let removed = 0;
     let skipped = 0;
+    let ambiguous = 0;
 
     // One walk for both extensions; visiting the tree is the expensive part.
     for (const path of collectFiles(tree, '', ['.html', '.ts'])) {
       const source = tree.read(path)?.toString();
       if (!source) continue;
 
-      if (path.endsWith('.html')) {
-        const result = migrateTemplate(source);
-        if (!result) continue;
-
-        tree.overwrite(path, result.content);
-        renamed += result.renamed;
-        removed += result.removed;
-        continue;
-      }
-
-      const result = migrateInlineTemplates(source);
+      const result = path.endsWith('.html')
+        ? migrateTemplate(source)
+        : migrateInlineTemplates(source);
       if (!result) continue;
 
       if (result.content !== source) tree.overwrite(path, result.content);
       renamed += result.renamed;
       removed += result.removed;
 
+      // A template that doesn't parse is already broken, so there is nothing
+      // worth migrating in it - but say so rather than passing over it quietly.
       if (result.skipped) {
         skipped += result.skipped;
         context.logger.warn(
-          `  ↳ Could not parse an inline template in ${path}. Rename translocoRead to translocoPrefix by hand.`,
+          `  ↳ Unable to parse ${path}, skipping. Rename translocoRead to translocoPrefix by hand.`,
+        );
+      }
+
+      if (result.ambiguous) {
+        ambiguous += result.ambiguous;
+        context.logger.warn(
+          `  ↳ ${path} binds translocoPrefix to an expression alongside translocoRead.\n` +
+            `    v8 fell back to the read whenever that expression was empty, which only the\n` +
+            `    running app can decide - the read was dropped, so check this one by hand.`,
         );
       }
     }
@@ -62,7 +66,7 @@ function migrateTranslocoRead(): Rule {
       );
     }
 
-    if (!renamed && !removed && !skipped) {
+    if (!renamed && !removed && !skipped && !ambiguous) {
       context.logger.info('  ↳ No translocoRead usages found.');
     }
   };

--- a/libs/transloco/migrations/v9/index.ts
+++ b/libs/transloco/migrations/v9/index.ts
@@ -47,8 +47,9 @@ function migrateTranslocoRead(): Rule {
       if (result.ambiguous) {
         ambiguous += result.ambiguous;
         context.logger.warn(
-          `  ↳ ${path} binds translocoPrefix to an expression alongside translocoRead.\n` +
-            `    v8 fell back to the read whenever that expression was empty, which only the\n` +
+          `  ↳ ${path} sets translocoPrefix alongside translocoRead, to an expression or\n` +
+            `    to an interpolated value this migration cannot read.\n` +
+            `    v8 fell back to the read whenever that prefix came out empty, which only the\n` +
             `    running app can decide - the read was dropped, so check this one by hand.`,
         );
       }

--- a/libs/transloco/migrations/v9/lazy-deps.ts
+++ b/libs/transloco/migrations/v9/lazy-deps.ts
@@ -1,0 +1,82 @@
+/**
+ * Every package the migration leans on is resolved lazily and defensively.
+ *
+ * All of them ship with a normal Angular workspace, but they arrive by
+ * different routes - `@schematics/angular` only comes with `@angular/cli` or
+ * `@nx/angular`, not with `@angular/build` - and these are top-level imports in
+ * a rule chain. Letting one missing package throw at module load would take the
+ * whole migration down, template rewrite included, rather than degrading to a
+ * warning about the one part that could not run.
+ */
+
+import { createRequire } from 'node:module';
+
+import type { Rule, Tree } from '@angular-devkit/schematics';
+
+/** Resolves from this file, so the workspace's own copies are the ones found. */
+const resolve = createRequire(__filename);
+
+type CompilerModule = typeof import('@angular/compiler');
+type TypeScriptModule = typeof import('typescript');
+
+interface StandaloneRules {
+  addRootProvider: (
+    project: string,
+    callback: (api: {
+      code: (strings: TemplateStringsArray, ...args: unknown[]) => unknown;
+      external: (symbol: string, moduleName: string) => unknown;
+    }) => unknown,
+  ) => Rule;
+  getMainFilePath: (tree: Tree, project: string) => Promise<string>;
+}
+
+/** `undefined` means "not tried yet"; `null` means "tried, not available". */
+let compiler: CompilerModule | null | undefined;
+let typescript: TypeScriptModule | null | undefined;
+let standalone: StandaloneRules | null | undefined;
+
+function attempt<T>(load: () => T): T | null {
+  try {
+    return load();
+  } catch {
+    return null;
+  }
+}
+
+/** The template parser. A direct dependency of every `ng new` workspace. */
+export function loadCompiler(): CompilerModule | null {
+  if (compiler === undefined) {
+    compiler = attempt(() => resolve('@angular/compiler') as CompilerModule);
+  }
+
+  return compiler;
+}
+
+/** Used to find inline templates and to read import declarations. */
+export function loadTypeScript(): TypeScriptModule | null {
+  if (typescript === undefined) {
+    typescript = attempt(() => resolve('typescript') as TypeScriptModule);
+  }
+
+  return typescript;
+}
+
+/** The root-provider helpers, which only ship with the CLI or `@nx/angular`. */
+export function loadStandaloneRules(): StandaloneRules | null {
+  if (standalone === undefined) {
+    standalone = attempt(() => ({
+      addRootProvider: (
+        resolve(
+          '@schematics/angular/utility/standalone/rules',
+        ) as StandaloneRules
+      ).addRootProvider,
+      getMainFilePath: (
+        resolve(
+          '@schematics/angular/utility/standalone/util',
+        ) as StandaloneRules
+      ).getMainFilePath,
+    }));
+  }
+
+  return standalone;
+}

--- a/libs/transloco/migrations/v9/migration-v9.spec.ts
+++ b/libs/transloco/migrations/v9/migration-v9.spec.ts
@@ -1,0 +1,406 @@
+import * as nodePath from 'node:path';
+
+import { HostTree } from '@angular-devkit/schematics';
+import {
+  SchematicTestRunner,
+  UnitTestTree,
+} from '@angular-devkit/schematics/testing';
+
+import { createWorkspace } from '../../schematics-core/testing';
+
+import { migrateInlineTemplates, migrateTemplate } from './template-utils';
+import { usesGlobalTranslateFn } from './global-translate-fn';
+
+const collectionPath = nodePath.join(__dirname, '../migration.json');
+
+describe('migrateTemplate', () => {
+  it(`GIVEN a static translocoRead attribute
+      WHEN the template is migrated
+      THEN it is renamed to translocoPrefix`, () => {
+    const result = migrateTemplate(
+      `<ng-template transloco let-t translocoRead="templates.translations"></ng-template>`,
+    );
+
+    expect(result?.content).toBe(
+      `<ng-template transloco let-t translocoPrefix="templates.translations"></ng-template>`,
+    );
+    expect(result?.renamed).toBe(1);
+    expect(result?.removed).toBe(0);
+  });
+
+  it(`GIVEN a bound translocoRead attribute
+      WHEN the template is migrated
+      THEN the binding brackets are preserved`, () => {
+    const result = migrateTemplate(
+      `<ng-template transloco let-b [translocoRead]="'nested.translation'"></ng-template>`,
+    );
+
+    expect(result?.content).toBe(
+      `<ng-template transloco let-b [translocoPrefix]="'nested.translation'"></ng-template>`,
+    );
+  });
+
+  it(`GIVEN an element carrying both translocoRead and translocoPrefix
+      WHEN the template is migrated
+      THEN translocoRead is dropped rather than renamed`, () => {
+    // v8 resolved `this.prefix || this.inlineRead`, so prefix already won.
+    // Renaming would emit a duplicate attribute, which fails to parse.
+    const result = migrateTemplate(
+      `<ng-template transloco translocoRead="a" translocoPrefix="b"></ng-template>`,
+    );
+
+    expect(result?.content).toBe(
+      `<ng-template transloco translocoPrefix="b"></ng-template>`,
+    );
+    expect(result?.removed).toBe(1);
+    expect(result?.renamed).toBe(0);
+  });
+
+  it(`GIVEN the *transloco microsyntax using the read key
+      WHEN the template is migrated
+      THEN the key is renamed to prefix`, () => {
+    const result = migrateTemplate(
+      `<ng-container *transloco="let t; read: 'ternary.nested'"></ng-container>`,
+    );
+
+    expect(result?.content).toBe(
+      `<ng-container *transloco="let t; prefix: 'ternary.nested'"></ng-container>`,
+    );
+    expect(result?.renamed).toBe(1);
+  });
+
+  it(`GIVEN the *transloco microsyntax combining read with other keys
+      WHEN the template is migrated
+      THEN the surrounding keys are preserved`, () => {
+    const result = migrateTemplate(
+      `<section *transloco="let t; read: 'a'; scope: 'lazy-page'; lang: 'es'"></section>`,
+    );
+
+    expect(result?.content).toBe(
+      `<section *transloco="let t; prefix: 'a'; scope: 'lazy-page'; lang: 'es'"></section>`,
+    );
+  });
+
+  it(`GIVEN the *transloco microsyntax carrying both read and prefix
+      WHEN the template is migrated
+      THEN the read segment is dropped`, () => {
+    const result = migrateTemplate(
+      `<div *transloco="let t; read: 'a'; prefix: 'b'"></div>`,
+    );
+
+    expect(result?.content).toBe(`<div *transloco="let t; prefix: 'b'"></div>`);
+    expect(result?.removed).toBe(1);
+    expect(result?.renamed).toBe(0);
+  });
+
+  it(`GIVEN a *transloco microsyntax without a read key
+      WHEN the template is migrated
+      THEN null is returned so the file is not rewritten`, () => {
+    expect(
+      migrateTemplate(
+        `<section *transloco="let t; scope: 'lazy-page'"></section>`,
+      ),
+    ).toBeNull();
+  });
+
+  it(`GIVEN an unrelated attribute whose value contains the word read
+      WHEN the template is migrated
+      THEN it is left untouched`, () => {
+    expect(
+      migrateTemplate(`<div *ngIf="hasRead" data-x="read: 'a'"></div>`),
+    ).toBeNull();
+  });
+
+  it(`GIVEN a microsyntax key that merely starts with read
+      WHEN the template is migrated
+      THEN it is left untouched`, () => {
+    // `readOnly:` maps to a translocoReadOnly input, not translocoRead.
+    expect(
+      migrateTemplate(`<div *transloco="let t; readOnly: 'a'"></div>`),
+    ).toBeNull();
+  });
+
+  it(`GIVEN a microsyntax read key with no space after the colon
+      WHEN the template is migrated
+      THEN it is renamed`, () => {
+    expect(
+      migrateTemplate(`<div *transloco="let t; read:'a'"></div>`)?.content,
+    ).toBe(`<div *transloco="let t; prefix:'a'"></div>`);
+  });
+
+  it(`GIVEN a *transloco attribute delimited by single quotes
+      WHEN the template is migrated
+      THEN the delimiter is preserved`, () => {
+    expect(
+      migrateTemplate(`<div *transloco='let t; read: "a"'></div>`)?.content,
+    ).toBe(`<div *transloco='let t; prefix: "a"'></div>`);
+  });
+
+  it(`GIVEN a *transloco attribute spanning several lines
+      WHEN the template is migrated
+      THEN the read key is still found`, () => {
+    const result = migrateTemplate(
+      [
+        `<ng-container`,
+        `  *transloco="let t; scope: 'ds'; lang: 'es'; read: 'nav'"`,
+        `>`,
+        `</ng-container>`,
+      ].join('\n'),
+    );
+
+    expect(result?.content).toContain(
+      `*transloco="let t; scope: 'ds'; lang: 'es'; prefix: 'nav'"`,
+    );
+    expect(result?.renamed).toBe(1);
+  });
+
+  it(`GIVEN an attribute value containing a greater-than sign
+      WHEN the template is migrated
+      THEN the tag boundary is respected`, () => {
+    const result = migrateTemplate(
+      `<ng-template transloco [translocoRead]="a > b ? 'x' : 'y'"></ng-template>`,
+    );
+
+    expect(result?.content).toBe(
+      `<ng-template transloco [translocoPrefix]="a > b ? 'x' : 'y'"></ng-template>`,
+    );
+  });
+
+  it(`GIVEN an attribute whose name merely starts with translocoRead
+      WHEN the template is migrated
+      THEN it is left untouched`, () => {
+    expect(migrateTemplate(`<div translocoReadonly="x"></div>`)).toBeNull();
+  });
+
+  it(`GIVEN a template without translocoRead
+      WHEN the template is migrated
+      THEN null is returned so the file is not rewritten`, () => {
+    expect(migrateTemplate(`<div translocoPrefix="a"></div>`)).toBeNull();
+  });
+});
+
+describe('migrateInlineTemplates', () => {
+  it(`GIVEN a component with an inline template using translocoRead
+      WHEN the source is migrated
+      THEN only the template literal is rewritten`, () => {
+    const source = [
+      `@Component({`,
+      '  template: `<ng-template transloco translocoRead="a"></ng-template>`,',
+      `})`,
+      `export class Foo {`,
+      `  readonly label = 'translocoRead';`,
+      `}`,
+    ].join('\n');
+
+    const result = migrateInlineTemplates(source);
+
+    expect(result?.content).toContain('translocoPrefix="a"');
+    expect(result?.content).toContain(`readonly label = 'translocoRead';`);
+    expect(result?.renamed).toBe(1);
+  });
+
+  it(`GIVEN a template literal containing an interpolated expression
+      WHEN the source is migrated
+      THEN the literal is still bounded correctly`, () => {
+    const source =
+      '@Component({ template: `<div translocoRead="a">${cond ? `x` : `y`}</div>` })';
+
+    const result = migrateInlineTemplates(source);
+
+    expect(result?.content).toBe(
+      '@Component({ template: `<div translocoPrefix="a">${cond ? `x` : `y`}</div>` })',
+    );
+  });
+
+  it(`GIVEN a file mentioning translocoRead outside any template
+      WHEN the source is migrated
+      THEN nothing is rewritten`, () => {
+    const source = `const attr = 'translocoRead';`;
+
+    expect(migrateInlineTemplates(source)?.content ?? source).toBe(source);
+  });
+
+  it(`GIVEN an inline template using the *transloco microsyntax
+      WHEN the source is migrated
+      THEN the read key is renamed`, () => {
+    const source =
+      '@Component({ template: `<div *transloco="let t; read: \'a\'"></div>` })';
+
+    expect(migrateInlineTemplates(source)?.content).toBe(
+      '@Component({ template: `<div *transloco="let t; prefix: \'a\'"></div>` })',
+    );
+  });
+});
+
+describe('usesGlobalTranslateFn', () => {
+  it(`GIVEN a file importing translate from @jsverse/transloco
+      WHEN it is inspected
+      THEN it reports usage`, () => {
+    expect(
+      usesGlobalTranslateFn(`import { translate } from '@jsverse/transloco';`),
+    ).toBe(true);
+  });
+
+  it(`GIVEN a file importing translateObject under an alias
+      WHEN it is inspected
+      THEN it reports usage`, () => {
+    expect(
+      usesGlobalTranslateFn(
+        `import { translateObject as t } from '@jsverse/transloco';`,
+      ),
+    ).toBe(true);
+  });
+
+  it(`GIVEN a locally defined translate helper
+      WHEN it is inspected
+      THEN it does not report usage`, () => {
+    expect(
+      usesGlobalTranslateFn(
+        [
+          `import { TranslocoService } from '@jsverse/transloco';`,
+          `function translate(key: string) { return key; }`,
+        ].join('\n'),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('migration-v9', () => {
+  const schematicRunner = new SchematicTestRunner('migrations', collectionPath);
+
+  async function run(setup: (tree: UnitTestTree) => void) {
+    const tree = await createWorkspace(schematicRunner);
+    setup(tree);
+
+    return schematicRunner.runSchematic('migration-v9', {}, tree);
+  }
+
+  it(`GIVEN a workspace with a template using translocoRead
+      WHEN the migration runs
+      THEN the template is rewritten in place`, async () => {
+    const tree = await run((host) =>
+      host.create(
+        '/projects/bar/src/app/feature.html',
+        `<ng-template transloco let-t translocoRead="home"></ng-template>`,
+      ),
+    );
+
+    expect(tree.readContent('/projects/bar/src/app/feature.html')).toBe(
+      `<ng-template transloco let-t translocoPrefix="home"></ng-template>`,
+    );
+  });
+
+  it(`GIVEN an application importing translate()
+      WHEN the migration runs
+      THEN provideGlobalTranslateFn() is added to its providers`, async () => {
+    const tree = await run((host) =>
+      host.create(
+        '/projects/bar/src/app/greeter.ts',
+        [
+          `import { translate } from '@jsverse/transloco';`,
+          `export const greet = () => translate('hello');`,
+        ].join('\n'),
+      ),
+    );
+
+    const config = tree
+      .readContent('/projects/bar/src/app/app.config.ts')
+      .replace(/\s+/g, ' ');
+
+    expect(config).toContain('provideGlobalTranslateFn()');
+    expect(config).toContain('@jsverse/transloco');
+  });
+
+  it(`GIVEN an application that does not use the standalone functions
+      WHEN the migration runs
+      THEN no provider is added`, async () => {
+    const tree = await run((host) =>
+      host.create(
+        '/projects/bar/src/app/greeter.ts',
+        [
+          `import { TranslocoService } from '@jsverse/transloco';`,
+          `export const service = TranslocoService;`,
+        ].join('\n'),
+      ),
+    );
+
+    expect(
+      tree.readContent('/projects/bar/src/app/app.config.ts'),
+    ).not.toContain('provideGlobalTranslateFn');
+  });
+
+  it(`GIVEN an application that already provides the global translate fn
+      WHEN the migration runs
+      THEN the provider is not added twice`, async () => {
+    const tree = await run((host) =>
+      host.create(
+        '/projects/bar/src/app/greeter.ts',
+        [
+          `import { translate, provideGlobalTranslateFn } from '@jsverse/transloco';`,
+          `export const providers = [provideGlobalTranslateFn()];`,
+          `export const greet = () => translate('hello');`,
+        ].join('\n'),
+      ),
+    );
+
+    const occurrences = tree
+      .readContent('/projects/bar/src/app/app.config.ts')
+      .match(/provideGlobalTranslateFn/g);
+
+    expect(occurrences).toBeNull();
+  });
+});
+
+describe('migration-v9 without a workspace file', () => {
+  // Nx serves a virtual angular.json through its CLI adapter, so the normal
+  // path covers `nx migrate`. This is the case where there is no workspace at
+  // all - a bare library, or an Nx repo without the Angular plugin.
+  const schematicRunner = new SchematicTestRunner('migrations', collectionPath);
+
+  function createBareTree() {
+    const tree = new UnitTestTree(new HostTree());
+    tree.create('/package.json', JSON.stringify({ name: 'bare' }));
+
+    return tree;
+  }
+
+  it(`GIVEN no angular.json
+      WHEN a template uses translocoRead
+      THEN it is still migrated`, async () => {
+    const tree = createBareTree();
+    tree.create(
+      '/src/app.html',
+      `<ng-container *transloco="let t; read: 'home'"></ng-container>`,
+    );
+
+    const result = await schematicRunner.runSchematic('migration-v9', {}, tree);
+
+    expect(result.readContent('/src/app.html')).toBe(
+      `<ng-container *transloco="let t; prefix: 'home'"></ng-container>`,
+    );
+  });
+
+  it(`GIVEN no angular.json
+      WHEN a file uses the standalone translate functions
+      THEN the migration names it instead of skipping silently`, async () => {
+    const tree = createBareTree();
+    tree.create(
+      '/src/greeter.ts',
+      [
+        `import { translate } from '@jsverse/transloco';`,
+        `export const greet = () => translate('hello');`,
+      ].join('\n'),
+    );
+
+    const warnings: string[] = [];
+    schematicRunner.logger.subscribe((entry) => {
+      if (entry.level === 'warn') warnings.push(entry.message);
+    });
+
+    await schematicRunner.runSchematic('migration-v9', {}, tree);
+
+    const reported = warnings.join('\n');
+    expect(reported).toContain('provideGlobalTranslateFn');
+    expect(reported).toContain('/src/greeter.ts');
+  });
+});

--- a/libs/transloco/migrations/v9/migration-v9.spec.ts
+++ b/libs/transloco/migrations/v9/migration-v9.spec.ts
@@ -9,7 +9,10 @@ import {
 import { createWorkspace } from '../../schematics-core/testing';
 
 import { migrateInlineTemplates, migrateTemplate } from './template-utils';
-import { usesGlobalTranslateFn } from './global-translate-fn';
+import {
+  providesGlobalTranslateFn,
+  usesGlobalTranslateFn,
+} from './global-translate-fn';
 
 const collectionPath = nodePath.join(__dirname, '../migration.json');
 
@@ -177,6 +180,204 @@ describe('migrateTemplate', () => {
       THEN null is returned so the file is not rewritten`, () => {
     expect(migrateTemplate(`<div translocoPrefix="a"></div>`)).toBeNull();
   });
+
+  it(`GIVEN microsyntax separated by commas
+      WHEN the template is migrated
+      THEN the read key is still renamed`, () => {
+    // Angular's microsyntax accepts `,` wherever it accepts `;`.
+    expect(
+      migrateTemplate(`<div *transloco="let t, read: 'a', lang: 'es'"></div>`)
+        ?.content,
+    ).toBe(`<div *transloco="let t, prefix: 'a', lang: 'es'"></div>`);
+  });
+
+  it(`GIVEN comma-separated microsyntax carrying both read and prefix
+      WHEN the template is migrated
+      THEN the read segment is dropped with its separator`, () => {
+    expect(
+      migrateTemplate(`<div *transloco="let t, read: 'a', prefix: 'b'"></div>`)
+        ?.content,
+    ).toBe(`<div *transloco="let t, prefix: 'b'"></div>`);
+  });
+
+  it(`GIVEN a read value containing a semicolon
+      WHEN the template is migrated
+      THEN the quoted value survives the rename`, () => {
+    expect(
+      migrateTemplate(`<div *transloco="let t; read: 'a;b'; lang: 'es'"></div>`)
+        ?.content,
+    ).toBe(`<div *transloco="let t; prefix: 'a;b'; lang: 'es'"></div>`);
+  });
+
+  it(`GIVEN a read value containing a semicolon alongside a prefix
+      WHEN the template is migrated
+      THEN the whole read segment is dropped, not a slice of it`, () => {
+    expect(
+      migrateTemplate(
+        `<div *transloco="let t; read: 'a;b'; prefix: 'c'"></div>`,
+      )?.content,
+    ).toBe(`<div *transloco="let t; prefix: 'c'"></div>`);
+  });
+
+  it(`GIVEN a read expression containing a semicolon and the word prefix
+      WHEN the template is migrated
+      THEN the expression is left intact`, () => {
+    expect(
+      migrateTemplate(
+        `<div *transloco="let t; read: format('; prefix:')"></div>`,
+      )?.content,
+    ).toBe(`<div *transloco="let t; prefix: format('; prefix:')"></div>`);
+  });
+
+  it(`GIVEN the read key sitting last in the microsyntax
+      WHEN the template is migrated
+      THEN no dangling separator is left behind`, () => {
+    expect(
+      migrateTemplate(`<div *transloco="let t; prefix: 'b'; read: 'a'"></div>`)
+        ?.content,
+    ).toBe(`<div *transloco="let t; prefix: 'b'"></div>`);
+  });
+
+  it(`GIVEN an unrelated attribute whose value contains the word translocoRead
+      WHEN the template is migrated
+      THEN the value is left untouched`, () => {
+    expect(migrateTemplate(`<div title="foo translocoRead bar"></div>`)).toBe(
+      null,
+    );
+  });
+
+  it(`GIVEN a binding expression referencing a variable named translocoRead
+      WHEN the template is migrated
+      THEN the expression is left untouched`, () => {
+    expect(
+      migrateTemplate(`<my-cmp [label]="translocoRead + suffix"></my-cmp>`),
+    ).toBeNull();
+  });
+
+  it(`GIVEN an attribute value mentioning translocoPrefix next to a real read
+      WHEN the template is migrated
+      THEN the read is renamed rather than silently deleted`, () => {
+    // The value is not a prefix binding, so nothing suppresses the rename.
+    expect(
+      migrateTemplate(
+        `<div data-doc="use translocoPrefix= instead" translocoRead="a"></div>`,
+      )?.content,
+    ).toBe(
+      `<div data-doc="use translocoPrefix= instead" translocoPrefix="a"></div>`,
+    );
+  });
+
+  it(`GIVEN the canonical bind- attribute form
+      WHEN the template is migrated
+      THEN only the input name is rewritten`, () => {
+    expect(
+      migrateTemplate(
+        `<ng-template transloco bind-translocoRead="a"></ng-template>`,
+      )?.content,
+    ).toBe(`<ng-template transloco bind-translocoPrefix="a"></ng-template>`);
+  });
+
+  it(`GIVEN a valueless translocoRead attribute
+      WHEN the template is migrated
+      THEN it is renamed`, () => {
+    expect(
+      migrateTemplate(`<ng-template transloco translocoRead></ng-template>`)
+        ?.content,
+    ).toBe(`<ng-template transloco translocoPrefix></ng-template>`);
+  });
+
+  it(`GIVEN a self-closing element
+      WHEN the template is migrated
+      THEN it is renamed`, () => {
+    expect(
+      migrateTemplate(`<ng-template transloco translocoRead="a" />`)?.content,
+    ).toBe(`<ng-template transloco translocoPrefix="a" />`);
+  });
+
+  it(`GIVEN both inputs bound on one element
+      WHEN the template is migrated
+      THEN only the prefix binding survives`, () => {
+    expect(
+      migrateTemplate(
+        `<ng-template transloco [translocoRead]="a" [translocoPrefix]="b"></ng-template>`,
+      )?.content,
+    ).toBe(`<ng-template transloco [translocoPrefix]="b"></ng-template>`);
+  });
+
+  it(`GIVEN an empty static prefix next to a read
+      WHEN the template is migrated
+      THEN the read wins, as it did in v8`, () => {
+    // v8 resolved `this.prefix || this.inlineRead`, so an empty prefix fell
+    // through to the read rather than suppressing it.
+    const result = migrateTemplate(
+      `<div translocoPrefix="" translocoRead="root"></div>`,
+    );
+
+    expect(result?.content).toBe(`<div translocoPrefix="root"></div>`);
+    expect(result?.renamed).toBe(1);
+    expect(result?.ambiguous).toBe(0);
+  });
+
+  it(`GIVEN an empty prefix key in the microsyntax
+      WHEN the template is migrated
+      THEN the read wins, as it did in v8`, () => {
+    expect(
+      migrateTemplate(
+        `<div *transloco="let t; prefix: ''; read: 'root'"></div>`,
+      )?.content,
+    ).toBe(`<div *transloco="let t; prefix: 'root'"></div>`);
+  });
+
+  it(`GIVEN a prefix bound to an expression next to a read
+      WHEN the template is migrated
+      THEN the read is dropped and the case is reported as ambiguous`, () => {
+    // Only the running app knows whether the expression is empty, so this one
+    // cannot be decided statically.
+    const result = migrateTemplate(
+      `<div [translocoPrefix]="maybeUndefined" translocoRead="fallback"></div>`,
+    );
+
+    expect(result?.content).toBe(
+      `<div [translocoPrefix]="maybeUndefined"></div>`,
+    );
+    expect(result?.ambiguous).toBe(1);
+  });
+
+  it(`GIVEN a template that cannot be parsed
+      WHEN the template is migrated
+      THEN it is reported as skipped rather than rewritten`, () => {
+    const source = `<div [translocoRead]="a b c ]]]"></div>`;
+    const result = migrateTemplate(source);
+
+    expect(result?.content).toBe(source);
+    expect(result?.skipped).toBe(1);
+    expect(result?.renamed).toBe(0);
+  });
+
+  it(`GIVEN an unparseable template with no hint of a read
+      WHEN the template is migrated
+      THEN it is passed over in silence`, () => {
+    expect(
+      migrateTemplate(`<div *transloco="let t; ]]]"></div>`)?.skipped ?? 0,
+    ).toBe(0);
+  });
+
+  it(`GIVEN a read binding inside a control-flow block
+      WHEN the template is migrated
+      THEN it is still found`, () => {
+    expect(
+      migrateTemplate(`@if (x) {\n  <p translocoRead="a"></p>\n}`)?.content,
+    ).toBe(`@if (x) {\n  <p translocoPrefix="a"></p>\n}`);
+  });
+
+  it(`GIVEN a template using CRLF line endings
+      WHEN the template is migrated
+      THEN the offsets still line up`, () => {
+    expect(
+      migrateTemplate(`<div>\r\n  <p translocoRead="a"></p>\r\n</div>`)
+        ?.content,
+    ).toBe(`<div>\r\n  <p translocoPrefix="a"></p>\r\n</div>`);
+  });
 });
 
 describe('migrateInlineTemplates', () => {
@@ -230,6 +431,81 @@ describe('migrateInlineTemplates', () => {
       '@Component({ template: `<div *transloco="let t; prefix: \'a\'"></div>` })',
     );
   });
+
+  it(`GIVEN an interpolation containing a brace inside a string
+      WHEN the source is migrated
+      THEN a later binding is still migrated`, () => {
+    // Counting braces in raw text ends the literal at the inner backtick and
+    // loses everything after it.
+    const source =
+      '@Component({ template: `<div>${format("}") ? `a` : `b`}</div><p translocoRead="x"></p>` })';
+
+    const result = migrateInlineTemplates(source);
+
+    expect(result?.content).toBe(
+      '@Component({ template: `<div>${format("}") ? `a` : `b`}</div><p translocoPrefix="x"></p>` })',
+    );
+    expect(result?.renamed).toBe(1);
+  });
+
+  it(`GIVEN the word template inside an unrelated string
+      WHEN the source is migrated
+      THEN the string is left untouched`, () => {
+    const source = `const note = "template: '<div translocoRead=\\"x\\"></div>'";`;
+
+    expect(migrateInlineTemplates(source)).toBeNull();
+  });
+
+  it(`GIVEN the word template inside a comment
+      WHEN the source is migrated
+      THEN the comment is left untouched`, () => {
+    const source = `// template: '<div translocoRead="x"></div>'\nconst a = 1;`;
+
+    expect(migrateInlineTemplates(source)).toBeNull();
+  });
+
+  it(`GIVEN a plain object property named template
+      WHEN the source is migrated
+      THEN only decorator metadata is rewritten`, () => {
+    const source = [
+      `const config = { template: '<div translocoRead="x"></div>' };`,
+      `@Component({ template: '<div translocoRead="y"></div>' })`,
+      `export class Foo {}`,
+    ].join('\n');
+
+    const result = migrateInlineTemplates(source);
+
+    expect(result?.content).toContain(
+      `const config = { template: '<div translocoRead="x"></div>' };`,
+    );
+    expect(result?.content).toContain(`translocoPrefix="y"`);
+    expect(result?.renamed).toBe(1);
+  });
+
+  it(`GIVEN a decorator whose earlier template needs no change
+      WHEN the source is migrated
+      THEN a nested template mention is not rescanned`, () => {
+    // The scan used to resume inside a literal it had already examined.
+    const source = [
+      `@Component({ template: '<p>no read here</p>' })`,
+      `export class A {}`,
+      `const doc = "template: '<div translocoRead=\\"y\\"></div>'";`,
+    ].join('\n');
+
+    expect(migrateInlineTemplates(source)).toBeNull();
+  });
+
+  it(`GIVEN an inline template that cannot be parsed
+      WHEN the source is migrated
+      THEN it is reported as skipped rather than rewritten`, () => {
+    const source =
+      '@Component({ template: `<div [translocoRead]="a b c ]]]"></div>` })';
+
+    const result = migrateInlineTemplates(source);
+
+    expect(result?.content).toBe(source);
+    expect(result?.skipped).toBe(1);
+  });
 });
 
 describe('usesGlobalTranslateFn', () => {
@@ -260,6 +536,104 @@ describe('usesGlobalTranslateFn', () => {
           `import { TranslocoService } from '@jsverse/transloco';`,
           `function translate(key: string) { return key; }`,
         ].join('\n'),
+      ),
+    ).toBe(false);
+  });
+
+  it(`GIVEN a type-only import of translate
+      WHEN it is inspected
+      THEN it does not report usage`, () => {
+    // Erased before the app runs, so no provider is needed - this is what
+    // keeps the documented SSR/MFE opt-out working.
+    expect(
+      usesGlobalTranslateFn(
+        `import type { translate } from '@jsverse/transloco';`,
+      ),
+    ).toBe(false);
+  });
+
+  it(`GIVEN an inline type specifier for translate
+      WHEN it is inspected
+      THEN it does not report usage`, () => {
+    expect(
+      usesGlobalTranslateFn(
+        `import { type translate, TranslocoService } from '@jsverse/transloco';`,
+      ),
+    ).toBe(false);
+  });
+
+  it(`GIVEN a namespace import whose translate is called
+      WHEN it is inspected
+      THEN it reports usage`, () => {
+    expect(
+      usesGlobalTranslateFn(
+        [
+          `import * as transloco from '@jsverse/transloco';`,
+          `export const greet = () => transloco.translate('hello');`,
+        ].join('\n'),
+      ),
+    ).toBe(true);
+  });
+
+  it(`GIVEN a namespace import that never calls the global functions
+      WHEN it is inspected
+      THEN it does not report usage`, () => {
+    expect(
+      usesGlobalTranslateFn(
+        [
+          `import * as transloco from '@jsverse/transloco';`,
+          `export const service = transloco.TranslocoService;`,
+        ].join('\n'),
+      ),
+    ).toBe(false);
+  });
+
+  it(`GIVEN translate imported from another package
+      WHEN it is inspected
+      THEN it does not report usage`, () => {
+    expect(
+      usesGlobalTranslateFn(`import { translate } from 'other-package';`),
+    ).toBe(false);
+  });
+});
+
+describe('providesGlobalTranslateFn', () => {
+  it(`GIVEN a file calling the provider
+      WHEN it is inspected
+      THEN it reports the project as wired`, () => {
+    expect(
+      providesGlobalTranslateFn(
+        `export const providers = [provideGlobalTranslateFn()];`,
+      ),
+    ).toBe(true);
+  });
+
+  it(`GIVEN the provider named only in a comment
+      WHEN it is inspected
+      THEN it does not report the project as wired`, () => {
+    // A mention must not make the migration believe the app is already set up
+    // and skip it - that would leave translate() returning ''.
+    expect(
+      providesGlobalTranslateFn(
+        `// remember to add provideGlobalTranslateFn() one day\nexport const x = 1;`,
+      ),
+    ).toBe(false);
+  });
+
+  it(`GIVEN the provider named only in a string
+      WHEN it is inspected
+      THEN it does not report the project as wired`, () => {
+    expect(
+      providesGlobalTranslateFn(`const doc = 'provideGlobalTranslateFn()';`),
+    ).toBe(false);
+  });
+
+  it(`GIVEN the provider imported but never called
+      WHEN it is inspected
+      THEN it does not report the project as wired`, () => {
+    expect(
+      providesGlobalTranslateFn(
+        `import { provideGlobalTranslateFn } from '@jsverse/transloco';`,
       ),
     ).toBe(false);
   });
@@ -329,25 +703,57 @@ describe('migration-v9', () => {
     ).not.toContain('provideGlobalTranslateFn');
   });
 
-  it(`GIVEN an application that already provides the global translate fn
+  it(`GIVEN an application that already registers the provider in its config
       WHEN the migration runs
-      THEN the provider is not added twice`, async () => {
+      THEN the provider is not added a second time`, async () => {
+    // `addRootProvider` inserts unconditionally, so a second call here would
+    // really produce two of them.
+    const tree = await run((host) => {
+      host.create(
+        '/projects/bar/src/app/greeter.ts',
+        [
+          `import { translate } from '@jsverse/transloco';`,
+          `export const greet = () => translate('hello');`,
+        ].join('\n'),
+      );
+      host.overwrite(
+        '/projects/bar/src/app/app.config.ts',
+        [
+          `import { ApplicationConfig } from '@angular/core';`,
+          `import { provideGlobalTranslateFn } from '@jsverse/transloco';`,
+          `export const appConfig: ApplicationConfig = {`,
+          `  providers: [provideGlobalTranslateFn()],`,
+          `};`,
+        ].join('\n'),
+      );
+    });
+
+    const occurrences = tree
+      .readContent('/projects/bar/src/app/app.config.ts')
+      .match(/provideGlobalTranslateFn\(\)/g);
+
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it(`GIVEN an application that only mentions the provider in a comment
+      WHEN the migration runs
+      THEN the provider is still added to the config`, async () => {
+    // The old substring guard treated any mention as "already wired", which
+    // silently left such applications without a provider.
     const tree = await run((host) =>
       host.create(
         '/projects/bar/src/app/greeter.ts',
         [
-          `import { translate, provideGlobalTranslateFn } from '@jsverse/transloco';`,
-          `export const providers = [provideGlobalTranslateFn()];`,
+          `import { translate } from '@jsverse/transloco';`,
+          `// TODO: call provideGlobalTranslateFn() at some point`,
           `export const greet = () => translate('hello');`,
         ].join('\n'),
       ),
     );
 
-    const occurrences = tree
-      .readContent('/projects/bar/src/app/app.config.ts')
-      .match(/provideGlobalTranslateFn/g);
-
-    expect(occurrences).toBeNull();
+    expect(tree.readContent('/projects/bar/src/app/app.config.ts')).toContain(
+      'provideGlobalTranslateFn()',
+    );
   });
 });
 

--- a/libs/transloco/migrations/v9/migration-v9.spec.ts
+++ b/libs/transloco/migrations/v9/migration-v9.spec.ts
@@ -506,6 +506,105 @@ describe('migrateInlineTemplates', () => {
     expect(result?.content).toBe(source);
     expect(result?.skipped).toBe(1);
   });
+
+  it(`GIVEN a static prefix written over an interpolation hole
+      WHEN the source is migrated
+      THEN the dropped read is reported as ambiguous`, () => {
+    // Masking blanks the hole, so the prefix parses as whitespace - non-empty,
+    // and so indistinguishable from a real static value without this check.
+    const source =
+      '@Component({ template: `<div translocoPrefix="${p}" translocoRead="fallback"></div>` })';
+
+    const result = migrateInlineTemplates(source);
+
+    expect(result?.content).toBe(
+      '@Component({ template: `<div translocoPrefix="${p}"></div>` })',
+    );
+    expect(result?.removed).toBe(1);
+    expect(result?.ambiguous).toBe(1);
+  });
+
+  it(`GIVEN a bound prefix written over an interpolation hole
+      WHEN the source is migrated
+      THEN the prefix survives and the read is reported as ambiguous`, () => {
+    // The masked expression is empty, which would otherwise read as "no prefix"
+    // and take the live binding down with the read it was renaming.
+    const source =
+      '@Component({ template: `<div [translocoPrefix]="${p}" translocoRead="fallback"></div>` })';
+
+    const result = migrateInlineTemplates(source);
+
+    expect(result?.content).toBe(
+      '@Component({ template: `<div [translocoPrefix]="${p}"></div>` })',
+    );
+    expect(result?.renamed).toBe(0);
+    expect(result?.removed).toBe(1);
+    expect(result?.ambiguous).toBe(1);
+  });
+
+  it(`GIVEN an interpolation hole away from the prefix
+      WHEN the source is migrated
+      THEN the static prefix is still decided without a warning`, () => {
+    const source =
+      '@Component({ template: `<div translocoPrefix="admin" translocoRead="fallback">${body}</div>` })';
+
+    const result = migrateInlineTemplates(source);
+
+    expect(result?.content).toBe(
+      '@Component({ template: `<div translocoPrefix="admin">${body}</div>` })',
+    );
+    expect(result?.removed).toBe(1);
+    expect(result?.ambiguous).toBe(0);
+  });
+
+  it(`GIVEN a microsyntax prefix written over an interpolation hole
+      WHEN the source is migrated
+      THEN the prefix survives and the read is reported as ambiguous`, () => {
+    // The microsyntax drops a blank value out of the binding's span, so this
+    // prefix reports the same span as a bare `prefix` - and removing it as an
+    // empty key used to leave the `: ${p}` behind it dangling.
+    const source =
+      '@Component({ template: `<div *transloco="let t; read: \'x\'; prefix: ${p}"></div>` })';
+
+    const result = migrateInlineTemplates(source);
+
+    expect(result?.content).toBe(
+      '@Component({ template: `<div *transloco="let t; prefix: ${p}"></div>` })',
+    );
+    expect(result?.renamed).toBe(0);
+    expect(result?.removed).toBe(1);
+    expect(result?.ambiguous).toBe(1);
+  });
+
+  it(`GIVEN a microsyntax hole ahead of the read
+      WHEN the source is migrated
+      THEN it is reported as skipped rather than rewritten`, () => {
+    // Masking leaves `prefix:  ; read`, which the expression parser rejects -
+    // so this one never reaches the classifier at all.
+    const source =
+      '@Component({ template: `<div *transloco="let t; prefix: ${p}; read: \'x\'"></div>` })';
+
+    const result = migrateInlineTemplates(source);
+
+    expect(result?.content).toBe(source);
+    expect(result?.skipped).toBe(1);
+  });
+
+  it(`GIVEN a read written over an interpolation hole with no prefix beside it
+      WHEN the source is migrated
+      THEN it is renamed as usual`, () => {
+    // Only the prefix decides the fallback, so a masked read is unaffected.
+    const source =
+      '@Component({ template: `<div translocoRead="${r}"></div>` })';
+
+    const result = migrateInlineTemplates(source);
+
+    expect(result?.content).toBe(
+      '@Component({ template: `<div translocoPrefix="${r}"></div>` })',
+    );
+    expect(result?.renamed).toBe(1);
+    expect(result?.ambiguous).toBe(0);
+  });
 });
 
 describe('usesGlobalTranslateFn', () => {

--- a/libs/transloco/migrations/v9/report-version-floors.ts
+++ b/libs/transloco/migrations/v9/report-version-floors.ts
@@ -1,0 +1,66 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+
+/** Node major required by the CLI packages as of v9 (was `>=18`). */
+const REQUIRED_NODE_MAJOR = 22;
+
+/** Angular major required by the Angular packages as of v9 (was `>=16`). */
+const REQUIRED_ANGULAR_MAJOR = 20;
+
+/** The CLI packages whose `engines.node` moved to `>=22`. */
+const NODE_PACKAGES = [
+  '@jsverse/transloco-optimize',
+  '@jsverse/transloco-scoped-libs',
+  '@jsverse/transloco-utils',
+  '@jsverse/transloco-validator',
+];
+
+function readMajor(range: string | undefined): number | null {
+  const match = range?.match(/(\d+)\s*\./);
+
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * Reports the v9 breaking changes that can't be applied to the source tree.
+ * The Angular check is informational - `ng update` already refuses on an
+ * unsatisfiable peer - but it never inspects `engines`, so Node is on us.
+ */
+export function reportVersionFloors(): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const nodeMajor = Number(process.versions.node.split('.')[0]);
+    if (nodeMajor < REQUIRED_NODE_MAJOR) {
+      context.logger.warn(
+        `  ↳ Node ${nodeMajor} detected. The Transloco CLI packages now require Node >=${REQUIRED_NODE_MAJOR}:\n` +
+          `    ${NODE_PACKAGES.join(', ')}.\n` +
+          `    chokidar was also bumped 3 -> 5 (ESM-only) in transloco-scoped-libs.`,
+      );
+    }
+
+    const buffer = tree.read('/package.json');
+    if (!buffer) return;
+
+    let packageJson: {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+
+    try {
+      packageJson = JSON.parse(buffer.toString());
+    } catch {
+      return;
+    }
+
+    const deps = {
+      ...packageJson.devDependencies,
+      ...packageJson.dependencies,
+    };
+
+    const angularMajor = readMajor(deps['@angular/core']);
+    if (angularMajor !== null && angularMajor < REQUIRED_ANGULAR_MAJOR) {
+      context.logger.warn(
+        `  ↳ @angular/core ${angularMajor} detected. Transloco v9 requires Angular >=${REQUIRED_ANGULAR_MAJOR}.\n` +
+          `    Run "ng update @angular/core @angular/cli" first.`,
+      );
+    }
+  };
+}

--- a/libs/transloco/migrations/v9/report-version-floors.ts
+++ b/libs/transloco/migrations/v9/report-version-floors.ts
@@ -3,64 +3,37 @@ import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 /** Node major required by the CLI packages as of v9 (was `>=18`). */
 const REQUIRED_NODE_MAJOR = 22;
 
-/** Angular major required by the Angular packages as of v9 (was `>=16`). */
-const REQUIRED_ANGULAR_MAJOR = 20;
-
 /** The CLI packages whose `engines.node` moved to `>=22`. */
 const NODE_PACKAGES = [
+  '@jsverse/transloco-keys-manager',
   '@jsverse/transloco-optimize',
   '@jsverse/transloco-scoped-libs',
   '@jsverse/transloco-utils',
   '@jsverse/transloco-validator',
 ];
 
-function readMajor(range: string | undefined): number | null {
-  const match = range?.match(/(\d+)\s*\./);
-
-  return match ? Number(match[1]) : null;
-}
-
 /**
  * Reports the v9 breaking changes that can't be applied to the source tree.
- * The Angular check is informational - `ng update` already refuses on an
- * unsatisfiable peer - but it never inspects `engines`, so Node is on us.
+ *
+ * Only Node is checked here. The Angular floor is declared instead - as a peer
+ * range, and as `requires` on the migration itself - which is how the rest of
+ * the ecosystem does it: `ng update` refuses on an unsatisfiable peer before
+ * any migration runs, and Nx evaluates `requires` itself. Parsing a version
+ * range by hand would only duplicate that, less reliably.
+ *
+ * Node has no such mechanism. `engines.node` is a warning under npm rather than
+ * a refusal, and it states intent rather than the interpreter actually running,
+ * so this reads the live version.
  */
 export function reportVersionFloors(): Rule {
-  return (tree: Tree, context: SchematicContext) => {
+  return (_tree: Tree, context: SchematicContext) => {
     const nodeMajor = Number(process.versions.node.split('.')[0]);
-    if (nodeMajor < REQUIRED_NODE_MAJOR) {
-      context.logger.warn(
-        `  ↳ Node ${nodeMajor} detected. The Transloco CLI packages now require Node >=${REQUIRED_NODE_MAJOR}:\n` +
-          `    ${NODE_PACKAGES.join(', ')}.\n` +
-          `    chokidar was also bumped 3 -> 5 (ESM-only) in transloco-scoped-libs.`,
-      );
-    }
+    if (nodeMajor >= REQUIRED_NODE_MAJOR) return;
 
-    const buffer = tree.read('/package.json');
-    if (!buffer) return;
-
-    let packageJson: {
-      dependencies?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-    };
-
-    try {
-      packageJson = JSON.parse(buffer.toString());
-    } catch {
-      return;
-    }
-
-    const deps = {
-      ...packageJson.devDependencies,
-      ...packageJson.dependencies,
-    };
-
-    const angularMajor = readMajor(deps['@angular/core']);
-    if (angularMajor !== null && angularMajor < REQUIRED_ANGULAR_MAJOR) {
-      context.logger.warn(
-        `  ↳ @angular/core ${angularMajor} detected. Transloco v9 requires Angular >=${REQUIRED_ANGULAR_MAJOR}.\n` +
-          `    Run "ng update @angular/core @angular/cli" first.`,
-      );
-    }
+    context.logger.warn(
+      `  ↳ Node ${nodeMajor} detected. The Transloco CLI packages now require Node >=${REQUIRED_NODE_MAJOR}:\n` +
+        `    ${NODE_PACKAGES.join(', ')}.\n` +
+        `    chokidar was also bumped 3 -> 5 (ESM-only) in transloco-scoped-libs.`,
+    );
   };
 }

--- a/libs/transloco/migrations/v9/template-utils.ts
+++ b/libs/transloco/migrations/v9/template-utils.ts
@@ -1,0 +1,264 @@
+/**
+ * Rewrites `translocoRead` out of templates as text rather than through
+ * `@angular/compiler`: re-printing the AST would reformat every template the
+ * migration touches.
+ */
+
+const PREFIX_ATTR = /(?:^|\s)\[?translocoPrefix\]?\s*=/;
+
+/**
+ * Captures the whitespace in front so removing a match doesn't leave a double
+ * space; the lookahead keeps `translocoReadonly`-style names from matching.
+ */
+const READ_ATTR =
+  /(\s*)(?:\[translocoRead\]|translocoRead)(\s*=\s*(?:"[^"]*"|'[^']*'|[^\s/>]+))?(?=[\s/>]|$)/g;
+
+/**
+ * Angular's microsyntax maps `read`/`prefix` onto the `translocoRead`/
+ * `translocoPrefix` inputs, so `*transloco="let t; read: 'a'"` needs migrating
+ * too - and it is the common form in the wild.
+ */
+const STRUCTURAL_ATTR = /(\*transloco\s*=\s*)("[^"]*"|'[^']*')/g;
+
+const MICRO_READ = /(^|;)(\s*)read(\s*:)/g;
+const MICRO_PREFIX = /(^|;)\s*prefix\s*:/;
+const MICRO_READ_SEGMENT = /^\s*read\s*:/;
+
+export interface MigrationResult {
+  content: string;
+  renamed: number;
+  /** Dropped because the tag already had a prefix. */
+  removed: number;
+}
+
+/**
+ * Yields the span of every opening tag. Quote state is tracked so a `>` inside
+ * an attribute value (`[translocoRead]="a > b ? 'x' : 'y'"`) doesn't end it.
+ */
+function* iterateTags(html: string): Generator<{ start: number; end: number }> {
+  let index = 0;
+
+  while (index < html.length) {
+    const open = html.indexOf('<', index);
+    if (open === -1) return;
+
+    // Skip comments, doctypes and closing tags.
+    if (!/[a-zA-Z]/.test(html[open + 1] ?? '')) {
+      index = open + 1;
+      continue;
+    }
+
+    let cursor = open + 1;
+    let quote: string | null = null;
+
+    while (cursor < html.length) {
+      const char = html[cursor];
+      if (quote) {
+        if (char === quote) quote = null;
+      } else if (char === '"' || char === "'") {
+        quote = char;
+      } else if (char === '>') {
+        break;
+      }
+      cursor++;
+    }
+
+    // Unterminated tag - stop rather than guess where it ends.
+    if (cursor >= html.length) return;
+
+    yield { start: open, end: cursor + 1 };
+    index = cursor + 1;
+  }
+}
+
+/** Rewrites the `read:` key inside one `*transloco` microsyntax value. */
+function migrateMicrosyntax(value: string): MigrationResult {
+  MICRO_READ.lastIndex = 0;
+  if (!MICRO_READ.test(value))
+    return { content: value, renamed: 0, removed: 0 };
+
+  // Prefix already won in v8, so a value carrying both loses the `read` segment
+  // rather than gaining a duplicate `prefix`.
+  if (MICRO_PREFIX.test(value)) {
+    const segments = value.split(';');
+    const kept = segments.filter(
+      (segment) => !MICRO_READ_SEGMENT.test(segment),
+    );
+
+    return {
+      content: kept.join(';'),
+      renamed: 0,
+      removed: segments.length - kept.length,
+    };
+  }
+
+  let renamed = 0;
+  MICRO_READ.lastIndex = 0;
+  const content = value.replace(
+    MICRO_READ,
+    (_match, separator: string, spacing: string, colon: string) => {
+      renamed++;
+
+      return `${separator}${spacing}prefix${colon}`;
+    },
+  );
+
+  return { content, renamed, removed: 0 };
+}
+
+function migrateTag(tag: string): MigrationResult {
+  // v8 resolved `this.prefix || this.inlineRead`, so renaming a read on a tag
+  // that already has a prefix would emit a duplicate attribute - a parse error.
+  const hasPrefix = PREFIX_ATTR.test(tag);
+  let renamed = 0;
+  let removed = 0;
+
+  let content = tag.replace(READ_ATTR, (match: string) => {
+    if (hasPrefix) {
+      removed++;
+
+      return '';
+    }
+
+    renamed++;
+
+    return match.replace('translocoRead', 'translocoPrefix');
+  });
+
+  STRUCTURAL_ATTR.lastIndex = 0;
+  content = content.replace(
+    STRUCTURAL_ATTR,
+    (_match, attribute: string, quoted: string) => {
+      const quote = quoted[0];
+      const result = migrateMicrosyntax(quoted.slice(1, -1));
+      renamed += result.renamed;
+      removed += result.removed;
+
+      return `${attribute}${quote}${result.content}${quote}`;
+    },
+  );
+
+  return { content, renamed, removed };
+}
+
+function mayContainRead(source: string): boolean {
+  return source.includes('translocoRead') || source.includes('*transloco');
+}
+
+/**
+ * Rewrites both forms in an HTML document. `null` when there is nothing to
+ * migrate, so callers can skip writing the file back.
+ */
+export function migrateTemplate(html: string): MigrationResult | null {
+  if (!mayContainRead(html)) return null;
+
+  let content = '';
+  let cursor = 0;
+  let renamed = 0;
+  let removed = 0;
+
+  for (const { start, end } of iterateTags(html)) {
+    const tag = html.slice(start, end);
+    if (!mayContainRead(tag)) continue;
+
+    const result = migrateTag(tag);
+    if (result.renamed === 0 && result.removed === 0) continue;
+
+    content += html.slice(cursor, start) + result.content;
+    cursor = end;
+    renamed += result.renamed;
+    removed += result.removed;
+  }
+
+  if (renamed === 0 && removed === 0) return null;
+
+  return { content: content + html.slice(cursor), renamed, removed };
+}
+
+const TEMPLATE_PROP = /\btemplate\s*:\s*/g;
+
+/**
+ * End index of the string literal opening at `start`, or `-1` if unterminated.
+ * Skips `${...}` so a backtick nested in an expression doesn't end the scan.
+ */
+function findLiteralEnd(source: string, start: number): number {
+  const quote = source[start];
+  let cursor = start + 1;
+
+  while (cursor < source.length) {
+    const char = source[cursor];
+
+    if (char === '\\') {
+      cursor += 2;
+      continue;
+    }
+
+    if (quote === '`' && char === '$' && source[cursor + 1] === '{') {
+      let depth = 1;
+      cursor += 2;
+      while (cursor < source.length && depth > 0) {
+        if (source[cursor] === '{') depth++;
+        else if (source[cursor] === '}') depth--;
+        cursor++;
+      }
+      continue;
+    }
+
+    if (char === quote) return cursor;
+
+    cursor++;
+  }
+
+  return -1;
+}
+
+export interface InlineTemplateResult extends MigrationResult {
+  /** Literals that look migratable but could not be bounded safely. */
+  skipped: number;
+}
+
+/**
+ * Rewrites inline `template:` literals only, never the surrounding source, so
+ * a plain string like `'translocoRead'` elsewhere in the file is left alone.
+ */
+export function migrateInlineTemplates(
+  source: string,
+): InlineTemplateResult | null {
+  if (!mayContainRead(source)) return null;
+
+  let content = '';
+  let cursor = 0;
+  let renamed = 0;
+  let removed = 0;
+  let skipped = 0;
+
+  TEMPLATE_PROP.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = TEMPLATE_PROP.exec(source)) !== null) {
+    const quoteIndex = match.index + match[0].length;
+    const quote = source[quoteIndex];
+    if (quote !== '`' && quote !== "'" && quote !== '"') continue;
+
+    const end = findLiteralEnd(source, quoteIndex);
+
+    if (end === -1) {
+      if (mayContainRead(source.slice(quoteIndex))) skipped++;
+      continue;
+    }
+
+    const literal = source.slice(quoteIndex + 1, end);
+    const result = migrateTemplate(literal);
+    if (!result) continue;
+
+    content += source.slice(cursor, quoteIndex + 1) + result.content;
+    cursor = end;
+    renamed += result.renamed;
+    removed += result.removed;
+    TEMPLATE_PROP.lastIndex = end;
+  }
+
+  if (renamed === 0 && removed === 0 && skipped === 0) return null;
+
+  return { content: content + source.slice(cursor), renamed, removed, skipped };
+}

--- a/libs/transloco/migrations/v9/template-utils.ts
+++ b/libs/transloco/migrations/v9/template-utils.ts
@@ -1,148 +1,307 @@
 /**
- * Rewrites `translocoRead` out of templates as text rather than through
- * `@angular/compiler`: re-printing the AST would reformat every template the
- * migration touches.
+ * Rewrites `translocoRead` out of templates.
+ *
+ * Both parsers below are used for *positions* only - the original text is
+ * spliced at the offsets they report, so formatting survives byte for byte.
+ * Re-printing an AST would reformat every template the migration touches, and
+ * matching on raw text - the obvious middle ground - cannot tell an attribute
+ * from the same word sitting inside another attribute's value.
  */
 
-const PREFIX_ATTR = /(?:^|\s)\[?translocoPrefix\]?\s*=/;
+import { loadCompiler, loadTypeScript } from './lazy-deps';
+
+type CompilerModule = NonNullable<ReturnType<typeof loadCompiler>>;
+type TypeScriptModule = NonNullable<ReturnType<typeof loadTypeScript>>;
+
+/** The v8 input and the v9 input that replaces it. */
+const READ_INPUT = 'translocoRead';
+const PREFIX_INPUT = 'translocoPrefix';
+
+/** Their microsyntax spellings inside `*transloco="..."`. */
+const READ_KEY = 'read';
+const PREFIX_KEY = 'prefix';
+
+/** Only the offsets are ever read, so this is all the span shape we need. */
+interface Span {
+  start: { offset: number };
+  end: { offset: number };
+}
 
 /**
- * Captures the whitespace in front so removing a match doesn't leave a double
- * space; the lookahead keeps `translocoReadonly`-style names from matching.
+ * Structural stand-in for `TmplAstBoundAttribute` / `TmplAstTextAttribute`.
+ * A text attribute carries its literal `value` as a string; a bound one holds
+ * an expression AST there instead, which is how the two are told apart without
+ * naming classes that have been reshaped between supported compiler versions.
  */
-const READ_ATTR =
-  /(\s*)(?:\[translocoRead\]|translocoRead)(\s*=\s*(?:"[^"]*"|'[^']*'|[^\s/>]+))?(?=[\s/>]|$)/g;
+interface Binding {
+  name: string;
+  keySpan: Span;
+  sourceSpan: Span;
+  valueSpan?: Span;
+  value?: unknown;
+}
 
-/**
- * Angular's microsyntax maps `read`/`prefix` onto the `translocoRead`/
- * `translocoPrefix` inputs, so `*transloco="let t; read: 'a'"` needs migrating
- * too - and it is the common form in the wild.
- */
-const STRUCTURAL_ATTR = /(\*transloco\s*=\s*)("[^"]*"|'[^']*')/g;
-
-const MICRO_READ = /(^|;)(\s*)read(\s*:)/g;
-const MICRO_PREFIX = /(^|;)\s*prefix\s*:/;
-const MICRO_READ_SEGMENT = /^\s*read\s*:/;
+interface Edit {
+  start: number;
+  end: number;
+  text: string;
+}
 
 export interface MigrationResult {
   content: string;
   renamed: number;
-  /** Dropped because the tag already had a prefix. */
+  /** Dropped because the same directive already had a prefix. */
   removed: number;
+  /** Templates that look migratable but could not be parsed. */
+  skipped: number;
+  /** Dropped where v8 could still have fallen back to `read` at runtime. */
+  ambiguous: number;
 }
 
 /**
- * Yields the span of every opening tag. Quote state is tracked so a `>` inside
- * an attribute value (`[translocoRead]="a > b ? 'x' : 'y'"`) doesn't end it.
+ * What v8's `this.prefix || this.inlineRead` would have resolved to.
+ *
+ * `none` means the prefix was falsy and `read` won, so the read is the value
+ * worth keeping. `ambiguous` means only the running application could tell.
  */
-function* iterateTags(html: string): Generator<{ start: number; end: number }> {
-  let index = 0;
+type PrefixState = 'none' | 'static' | 'ambiguous';
 
-  while (index < html.length) {
-    const open = html.indexOf('<', index);
-    if (open === -1) return;
+/** Expressions that are empty no matter what the application does. */
+const EMPTY_EXPRESSIONS = new Set(["''", '""', '``']);
 
-    // Skip comments, doctypes and closing tags.
-    if (!/[a-zA-Z]/.test(html[open + 1] ?? '')) {
-      index = open + 1;
-      continue;
-    }
-
-    let cursor = open + 1;
-    let quote: string | null = null;
-
-    while (cursor < html.length) {
-      const char = html[cursor];
-      if (quote) {
-        if (char === quote) quote = null;
-      } else if (char === '"' || char === "'") {
-        quote = char;
-      } else if (char === '>') {
-        break;
-      }
-      cursor++;
-    }
-
-    // Unterminated tag - stop rather than guess where it ends.
-    if (cursor >= html.length) return;
-
-    yield { start: open, end: cursor + 1 };
-    index = cursor + 1;
-  }
+/** Cheap gate so the parser only runs on files that could possibly match. */
+function mayContainRead(source: string): boolean {
+  return source.includes(READ_INPUT) || source.includes('*transloco');
 }
 
-/** Rewrites the `read:` key inside one `*transloco` microsyntax value. */
-function migrateMicrosyntax(value: string): MigrationResult {
-  MICRO_READ.lastIndex = 0;
-  if (!MICRO_READ.test(value))
-    return { content: value, renamed: 0, removed: 0 };
+/**
+ * Whether a source that failed to parse is worth telling the user about. A
+ * template with no hint of `read` is skipped in silence.
+ */
+function looksMigratable(source: string): boolean {
+  return source.includes(READ_INPUT) || /\bread\s*:/.test(source);
+}
 
-  // Prefix already won in v8, so a value carrying both loses the `read` segment
-  // rather than gaining a duplicate `prefix`.
-  if (MICRO_PREFIX.test(value)) {
-    const segments = value.split(';');
-    const kept = segments.filter(
-      (segment) => !MICRO_READ_SEGMENT.test(segment),
-    );
+function unparsed(content: string): MigrationResult {
+  return { content, renamed: 0, removed: 0, skipped: 1, ambiguous: 0 };
+}
 
-    return {
-      content: kept.join(';'),
-      renamed: 0,
-      removed: segments.length - kept.length,
-    };
-  }
+function isBinding(value: unknown): value is Binding {
+  const candidate = value as Binding | null;
 
-  let renamed = 0;
-  MICRO_READ.lastIndex = 0;
-  const content = value.replace(
-    MICRO_READ,
-    (_match, separator: string, spacing: string, colon: string) => {
-      renamed++;
-
-      return `${separator}${spacing}prefix${colon}`;
-    },
+  return (
+    !!candidate &&
+    typeof candidate === 'object' &&
+    typeof candidate.name === 'string' &&
+    !!candidate.keySpan &&
+    !!candidate.sourceSpan
   );
-
-  return { content, renamed, removed: 0 };
 }
 
-function migrateTag(tag: string): MigrationResult {
-  // v8 resolved `this.prefix || this.inlineRead`, so renaming a read on a tag
-  // that already has a prefix would emit a duplicate attribute - a parse error.
-  const hasPrefix = PREFIX_ATTR.test(tag);
+function bindingsAt(record: Record<string, unknown>, key: string): Binding[] {
+  const value = record[key];
+
+  return Array.isArray(value) ? value.filter(isBinding) : [];
+}
+
+/** Span-ish keys hold no child nodes, so walking into them is wasted work. */
+const NON_STRUCTURAL = /Span$|^i18n$|^file$|^start$|^end$/;
+
+/**
+ * Groups every binding by the directive instance that owns it.
+ *
+ * An element's own attributes and the microsyntax of a structural directive on
+ * that same element are separate instances, so each resolves `prefix || read`
+ * on its own and has to be judged separately.
+ *
+ * The walk is deliberately structural rather than `instanceof`-based: the
+ * migration runs against whatever `@angular/compiler` the workspace has, and
+ * the node classes have been reshaped between supported versions.
+ */
+function collectGroups(
+  node: unknown,
+  groups: Binding[][],
+  seen: Set<object>,
+): void {
+  if (!node || typeof node !== 'object' || seen.has(node)) return;
+  seen.add(node);
+
+  if (Array.isArray(node)) {
+    for (const child of node) collectGroups(child, groups, seen);
+
+    return;
+  }
+
+  const record = node as Record<string, unknown>;
+
+  const own = [
+    ...bindingsAt(record, 'attributes'),
+    ...bindingsAt(record, 'inputs'),
+  ];
+  if (own.length) groups.push(own);
+
+  const structural = bindingsAt(record, 'templateAttrs');
+  if (structural.length) groups.push(structural);
+
+  for (const [key, value] of Object.entries(record)) {
+    if (NON_STRUCTURAL.test(key)) continue;
+    if (value && typeof value === 'object') collectGroups(value, groups, seen);
+  }
+}
+
+function textOf(source: string, span: Span): string {
+  return source.slice(span.start.offset, span.end.offset);
+}
+
+/**
+ * Renames the key in place. The key span covers the bare input name in every
+ * spelling - `translocoRead`, `[translocoRead]`, `bind-translocoRead` - and the
+ * bare `read` in microsyntax, so the replacement follows from what it points at.
+ */
+function renameEdit(source: string, read: Binding): Edit {
+  const key = textOf(source, read.keySpan);
+
+  return {
+    start: read.keySpan.start.offset,
+    end: read.keySpan.end.offset,
+    text: key === READ_KEY ? PREFIX_KEY : PREFIX_INPUT,
+  };
+}
+
+/**
+ * Drops the binding entirely, along with the separator that joined it to its
+ * neighbour.
+ *
+ * A microsyntax span already swallows its trailing separator, so nothing more
+ * is needed there. When it doesn't - the `read` key came last - the preceding
+ * separator is taken instead, otherwise the value would end on a dangling `;`.
+ */
+function removalEdit(source: string, read: Binding): Edit {
+  const end = read.sourceSpan.end.offset;
+  let start = read.sourceSpan.start.offset;
+
+  if (!/[;,]\s*$/.test(textOf(source, read.sourceSpan))) {
+    while (start > 0 && /\s/.test(source[start - 1])) start--;
+
+    if (start > 0 && /[;,]/.test(source[start - 1])) {
+      start--;
+      while (start > 0 && /\s/.test(source[start - 1])) start--;
+    }
+  }
+
+  return { start, end, text: '' };
+}
+
+/**
+ * Decides what v8 would have done with the prefix sitting next to a `read`.
+ *
+ * v8 resolved `this.prefix || this.inlineRead`, so an empty prefix fell through
+ * to the read rather than winning - which makes dropping the read on an empty
+ * prefix a silent behaviour change.
+ */
+function classifyPrefix(
+  source: string,
+  prefix: Binding | undefined,
+): PrefixState {
+  if (!prefix) return 'none';
+
+  // A text attribute carries its literal value, so the fallback is decidable.
+  if (typeof prefix.value === 'string')
+    return prefix.value === '' ? 'none' : 'static';
+
+  const expression = prefix.valueSpan
+    ? textOf(source, prefix.valueSpan).trim()
+    : '';
+
+  if (expression === '' || EMPTY_EXPRESSIONS.has(expression)) return 'none';
+
+  // A bound prefix can still evaluate to undefined, which v8 resolved to the
+  // read. Nothing static can tell, so the caller reports it instead.
+  return 'ambiguous';
+}
+
+function applyEdits(source: string, edits: Edit[]): string {
+  const ordered = [...edits].sort((a, b) => a.start - b.start);
+  let content = '';
+  let cursor = 0;
+
+  for (const edit of ordered) {
+    if (edit.start < cursor) continue;
+    content += source.slice(cursor, edit.start) + edit.text;
+    cursor = edit.end;
+  }
+
+  return content + source.slice(cursor);
+}
+
+/**
+ * Collects the edits for one parsed template. `null` when the source could not
+ * be parsed, which the callers turn into a skip.
+ */
+function templateEdits(
+  source: string,
+  offset: number,
+  compiler: CompilerModule,
+): {
+  edits: Edit[];
+  renamed: number;
+  removed: number;
+  ambiguous: number;
+} | null {
+  let parsed;
+
+  try {
+    parsed = compiler.parseTemplate(source, 'transloco-migration.html', {
+      preserveWhitespaces: true,
+    });
+  } catch {
+    return null;
+  }
+
+  if (parsed.errors?.length) return null;
+
+  const groups: Binding[][] = [];
+  collectGroups(parsed.nodes, groups, new Set());
+
+  const edits: Edit[] = [];
   let renamed = 0;
   let removed = 0;
+  let ambiguous = 0;
 
-  let content = tag.replace(READ_ATTR, (match: string) => {
-    if (hasPrefix) {
-      removed++;
-
-      return '';
-    }
-
-    renamed++;
-
-    return match.replace('translocoRead', 'translocoPrefix');
+  const shift = (edit: Edit): Edit => ({
+    start: edit.start + offset,
+    end: edit.end + offset,
+    text: edit.text,
   });
 
-  STRUCTURAL_ATTR.lastIndex = 0;
-  content = content.replace(
-    STRUCTURAL_ATTR,
-    (_match, attribute: string, quoted: string) => {
-      const quote = quoted[0];
-      const result = migrateMicrosyntax(quoted.slice(1, -1));
-      renamed += result.renamed;
-      removed += result.removed;
+  for (const group of groups) {
+    const reads = group.filter((binding) => binding.name === READ_INPUT);
+    if (!reads.length) continue;
 
-      return `${attribute}${quote}${result.content}${quote}`;
-    },
-  );
+    const prefix = group.find((binding) => binding.name === PREFIX_INPUT);
+    const state = classifyPrefix(source, prefix);
 
-  return { content, renamed, removed };
-}
+    for (const read of reads) {
+      if (state === 'none') {
+        edits.push(shift(renameEdit(source, read)));
+        renamed++;
+        continue;
+      }
 
-function mayContainRead(source: string): boolean {
-  return source.includes('translocoRead') || source.includes('*transloco');
+      // A directive carrying a real prefix already ignored the read in v8, so
+      // renaming would emit a duplicate binding rather than restore anything.
+      edits.push(shift(removalEdit(source, read)));
+      removed++;
+      if (state === 'ambiguous') ambiguous++;
+    }
+
+    // The read has just taken the prefix's name, so the empty prefix that let
+    // it win in the first place has to go with it.
+    if (state === 'none' && prefix)
+      edits.push(shift(removalEdit(source, prefix)));
+  }
+
+  return { edits, renamed, removed, ambiguous };
 }
 
 /**
@@ -152,113 +311,164 @@ function mayContainRead(source: string): boolean {
 export function migrateTemplate(html: string): MigrationResult | null {
   if (!mayContainRead(html)) return null;
 
-  let content = '';
-  let cursor = 0;
-  let renamed = 0;
-  let removed = 0;
+  const compiler = loadCompiler();
+  if (!compiler) return looksMigratable(html) ? unparsed(html) : null;
 
-  for (const { start, end } of iterateTags(html)) {
-    const tag = html.slice(start, end);
-    if (!mayContainRead(tag)) continue;
+  const result = templateEdits(html, 0, compiler);
+  if (!result) return looksMigratable(html) ? unparsed(html) : null;
 
-    const result = migrateTag(tag);
-    if (result.renamed === 0 && result.removed === 0) continue;
+  if (!result.renamed && !result.removed) return null;
 
-    content += html.slice(cursor, start) + result.content;
-    cursor = end;
-    renamed += result.renamed;
-    removed += result.removed;
-  }
-
-  if (renamed === 0 && removed === 0) return null;
-
-  return { content: content + html.slice(cursor), renamed, removed };
+  return {
+    content: applyEdits(html, result.edits),
+    renamed: result.renamed,
+    removed: result.removed,
+    skipped: 0,
+    ambiguous: result.ambiguous,
+  };
 }
-
-const TEMPLATE_PROP = /\btemplate\s*:\s*/g;
 
 /**
- * End index of the string literal opening at `start`, or `-1` if unterminated.
- * Skips `${...}` so a backtick nested in an expression doesn't end the scan.
+ * The static stretches of a template literal, as offsets into the file.
+ *
+ * Everything else - the `${...}` holes - is masked out before parsing, which
+ * keeps every offset identical to the original source while hiding expressions
+ * the template parser has no business reading.
  */
-function findLiteralEnd(source: string, start: number): number {
-  const quote = source[start];
-  let cursor = start + 1;
+function staticRanges(
+  literal: import('typescript').Node,
+  ts: TypeScriptModule,
+): Array<[number, number]> {
+  if (
+    ts.isStringLiteral(literal) ||
+    ts.isNoSubstitutionTemplateLiteral(literal)
+  )
+    return [[literal.getStart() + 1, literal.getEnd() - 1]];
 
-  while (cursor < source.length) {
-    const char = source[cursor];
+  if (!ts.isTemplateExpression(literal)) return [];
 
-    if (char === '\\') {
-      cursor += 2;
-      continue;
-    }
+  // A head or middle token ends with the two characters `${`; a tail ends with
+  // the closing backtick. Each one opens with a single quote-ish character.
+  const ranges: Array<[number, number]> = [
+    [literal.head.getStart() + 1, literal.head.getEnd() - 2],
+  ];
 
-    if (quote === '`' && char === '$' && source[cursor + 1] === '{') {
-      let depth = 1;
-      cursor += 2;
-      while (cursor < source.length && depth > 0) {
-        if (source[cursor] === '{') depth++;
-        else if (source[cursor] === '}') depth--;
-        cursor++;
-      }
-      continue;
-    }
-
-    if (char === quote) return cursor;
-
-    cursor++;
+  for (const span of literal.templateSpans) {
+    const token = span.literal;
+    const trailing = ts.isTemplateTail(token) ? 1 : 2;
+    ranges.push([token.getStart() + 1, token.getEnd() - trailing]);
   }
 
-  return -1;
+  return ranges;
 }
 
-export interface InlineTemplateResult extends MigrationResult {
-  /** Literals that look migratable but could not be bounded safely. */
-  skipped: number;
+/** Blanks every character outside `ranges`, preserving length and offsets. */
+function maskOutside(
+  source: string,
+  from: number,
+  to: number,
+  ranges: Array<[number, number]>,
+): string {
+  const chars = new Array<string>(to - from).fill(' ');
+
+  for (const [start, end] of ranges) {
+    for (let index = start; index < end; index++) {
+      chars[index - from] = source[index];
+    }
+  }
+
+  return chars.join('');
+}
+
+/**
+ * Whether this `template:` property really belongs to a decorator's metadata
+ * object, rather than being a plain object property that happens to share the
+ * name - or the word `template:` sitting inside a string or a comment.
+ */
+function isDecoratorMetadata(
+  property: import('typescript').PropertyAssignment,
+  ts: TypeScriptModule,
+): boolean {
+  const object = property.parent;
+  if (!ts.isObjectLiteralExpression(object)) return false;
+
+  const call = object.parent;
+
+  return (
+    !!call &&
+    ts.isCallExpression(call) &&
+    call.arguments.some((argument) => argument === object) &&
+    ts.isDecorator(call.parent)
+  );
 }
 
 /**
  * Rewrites inline `template:` literals only, never the surrounding source, so
  * a plain string like `'translocoRead'` elsewhere in the file is left alone.
  */
-export function migrateInlineTemplates(
-  source: string,
-): InlineTemplateResult | null {
+export function migrateInlineTemplates(source: string): MigrationResult | null {
   if (!mayContainRead(source)) return null;
 
-  let content = '';
-  let cursor = 0;
+  const ts = loadTypeScript();
+  const compiler = loadCompiler();
+  if (!ts || !compiler)
+    return looksMigratable(source) ? unparsed(source) : null;
+
+  const file = ts.createSourceFile(
+    'transloco-migration.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  const edits: Edit[] = [];
   let renamed = 0;
   let removed = 0;
   let skipped = 0;
+  let ambiguous = 0;
 
-  TEMPLATE_PROP.lastIndex = 0;
-  let match: RegExpExecArray | null;
+  const visit = (node: import('typescript').Node): void => {
+    if (
+      ts.isPropertyAssignment(node) &&
+      (ts.isIdentifier(node.name) || ts.isStringLiteral(node.name)) &&
+      node.name.text === 'template' &&
+      isDecoratorMetadata(node, ts)
+    ) {
+      const literal = node.initializer;
+      const ranges = staticRanges(literal, ts);
 
-  while ((match = TEMPLATE_PROP.exec(source)) !== null) {
-    const quoteIndex = match.index + match[0].length;
-    const quote = source[quoteIndex];
-    if (quote !== '`' && quote !== "'" && quote !== '"') continue;
+      if (ranges.length) {
+        const from = literal.getStart();
+        const to = literal.getEnd();
+        const masked = maskOutside(source, from, to, ranges);
 
-    const end = findLiteralEnd(source, quoteIndex);
+        if (mayContainRead(masked)) {
+          const result = templateEdits(masked, from, compiler);
 
-    if (end === -1) {
-      if (mayContainRead(source.slice(quoteIndex))) skipped++;
-      continue;
+          if (!result) {
+            if (looksMigratable(masked)) skipped++;
+          } else {
+            edits.push(...result.edits);
+            renamed += result.renamed;
+            removed += result.removed;
+            ambiguous += result.ambiguous;
+          }
+        }
+      }
     }
 
-    const literal = source.slice(quoteIndex + 1, end);
-    const result = migrateTemplate(literal);
-    if (!result) continue;
+    ts.forEachChild(node, visit);
+  };
 
-    content += source.slice(cursor, quoteIndex + 1) + result.content;
-    cursor = end;
-    renamed += result.renamed;
-    removed += result.removed;
-    TEMPLATE_PROP.lastIndex = end;
-  }
+  ts.forEachChild(file, visit);
 
-  if (renamed === 0 && removed === 0 && skipped === 0) return null;
+  if (!renamed && !removed && !skipped) return null;
 
-  return { content: content + source.slice(cursor), renamed, removed, skipped };
+  return {
+    content: applyEdits(source, edits),
+    renamed,
+    removed,
+    skipped,
+    ambiguous,
+  };
 }

--- a/libs/transloco/migrations/v9/template-utils.ts
+++ b/libs/transloco/migrations/v9/template-utils.ts
@@ -193,6 +193,34 @@ function removalEdit(source: string, read: Binding): Edit {
 }
 
 /**
+ * How far to look for masking, given a binding.
+ *
+ * Angular drops a blank value out of the span - in the microsyntax that leaves
+ * nothing but the key, so `prefix: ${p}` reports the same span as a bare
+ * `prefix`. Walking over the `:` and the whitespace that follow puts the
+ * stretch the value would have occupied back in reach.
+ */
+function maskProbeEnd(source: string, span: Span): number {
+  let end = span.end.offset;
+  while (end < source.length && /[\s:]/.test(source[end])) end++;
+
+  return end;
+}
+
+/** Whether a binding covers any of the blanked-out stretches of a literal. */
+function overlapsMask(
+  source: string,
+  span: Span,
+  masked: Array<[number, number]>,
+): boolean {
+  const probeEnd = maskProbeEnd(source, span);
+
+  return masked.some(
+    ([start, end]) => span.start.offset < end && start < probeEnd,
+  );
+}
+
+/**
  * Decides what v8 would have done with the prefix sitting next to a `read`.
  *
  * v8 resolved `this.prefix || this.inlineRead`, so an empty prefix fell through
@@ -202,8 +230,19 @@ function removalEdit(source: string, read: Binding): Edit {
 function classifyPrefix(
   source: string,
   prefix: Binding | undefined,
+  masked: Array<[number, number]>,
 ): PrefixState {
   if (!prefix) return 'none';
+
+  // An inline template's `${...}` holes are blanked before parsing, so a prefix
+  // written over one reads as whitespace when static and as an empty expression
+  // when bound - decidable-looking either way, and neither is: only the running
+  // app knows what the hole stands for. Checked first, so neither branch below
+  // ever sees a value that masking invented.
+  //
+  // `sourceSpan`, not `valueSpan`: Angular collapses a blank value to a
+  // zero-length span, which overlaps nothing.
+  if (overlapsMask(source, prefix.sourceSpan, masked)) return 'ambiguous';
 
   // A text attribute carries its literal value, so the fallback is decidable.
   if (typeof prefix.value === 'string')
@@ -242,6 +281,7 @@ function templateEdits(
   source: string,
   offset: number,
   compiler: CompilerModule,
+  masked: Array<[number, number]> = [],
 ): {
   edits: Edit[];
   renamed: number;
@@ -279,7 +319,7 @@ function templateEdits(
     if (!reads.length) continue;
 
     const prefix = group.find((binding) => binding.name === PREFIX_INPUT);
-    const state = classifyPrefix(source, prefix);
+    const state = classifyPrefix(source, prefix, masked);
 
     for (const read of reads) {
       if (state === 'none') {
@@ -360,6 +400,31 @@ function staticRanges(
   }
 
   return ranges;
+}
+
+/**
+ * The stretches `maskOutside` blanks, as offsets into the masked string.
+ *
+ * `staticRanges` reports what survives, so the blanked stretches are the gaps
+ * left between them - the `${...}` holes, plus the quotes and backticks that
+ * delimit the literal itself.
+ */
+function maskedRanges(
+  from: number,
+  to: number,
+  ranges: Array<[number, number]>,
+): Array<[number, number]> {
+  const masked: Array<[number, number]> = [];
+  let cursor = from;
+
+  for (const [start, end] of ranges) {
+    if (start > cursor) masked.push([cursor - from, start - from]);
+    cursor = Math.max(cursor, end);
+  }
+
+  if (cursor < to) masked.push([cursor - from, to - from]);
+
+  return masked;
 }
 
 /** Blanks every character outside `ranges`, preserving length and offsets. */
@@ -443,7 +508,12 @@ export function migrateInlineTemplates(source: string): MigrationResult | null {
         const masked = maskOutside(source, from, to, ranges);
 
         if (mayContainRead(masked)) {
-          const result = templateEdits(masked, from, compiler);
+          const result = templateEdits(
+            masked,
+            from,
+            compiler,
+            maskedRanges(from, to, ranges),
+          );
 
           if (!result) {
             if (looksMigratable(masked)) skipped++;

--- a/libs/transloco/migrations/v9/workspace-utils.ts
+++ b/libs/transloco/migrations/v9/workspace-utils.ts
@@ -1,0 +1,64 @@
+import { Tree } from '@angular-devkit/schematics';
+import { WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
+
+/** Directories that never contain sources worth migrating. */
+const IGNORED = /(^|\/)(node_modules|dist|\.git|\.angular|\.nx|coverage)(\/|$)/;
+
+export interface WorkspaceProject {
+  name: string;
+  root: string;
+  sourceRoot: string;
+  isApplication: boolean;
+}
+
+/**
+ * `null` when there is no workspace file. `ng update` also runs in repos that
+ * aren't CLI-managed; those still get the template migration, just not the
+ * per-project provider wiring.
+ */
+export function readWorkspace(tree: Tree): WorkspaceSchema | null {
+  const path = ['/angular.json', '/.angular.json'].find((candidate) =>
+    tree.exists(candidate),
+  );
+  if (!path) return null;
+
+  const buffer = tree.read(path);
+  if (!buffer) return null;
+
+  try {
+    return JSON.parse(buffer.toString()) as WorkspaceSchema;
+  } catch {
+    return null;
+  }
+}
+
+export function getProjects(tree: Tree): WorkspaceProject[] {
+  const workspace = readWorkspace(tree);
+  if (!workspace?.projects) return [];
+
+  return Object.entries(workspace.projects).map(([name, project]) => ({
+    name,
+    root: project.root ?? '',
+    sourceRoot: project.sourceRoot ?? `${project.root ?? ''}/src`,
+    isApplication: project.projectType !== 'library',
+  }));
+}
+
+/** Paths under `root` matching `extensions`, minus build and dependency dirs. */
+export function collectFiles(
+  tree: Tree,
+  root: string,
+  extensions: string[],
+): string[] {
+  const paths: string[] = [];
+  const normalized = root === '' || root === '/' ? '' : root.replace(/^\//, '');
+
+  tree.getDir(`/${normalized}`).visit((path) => {
+    if (IGNORED.test(path)) return;
+    if (extensions.some((extension) => path.endsWith(extension))) {
+      paths.push(path);
+    }
+  });
+
+  return paths;
+}

--- a/libs/transloco/migrations/v9/workspace-utils.ts
+++ b/libs/transloco/migrations/v9/workspace-utils.ts
@@ -17,15 +17,19 @@ export interface WorkspaceProject {
  * per-project provider wiring.
  */
 export function readWorkspace(tree: Tree): WorkspaceSchema | null {
-  const path = ['/angular.json', '/.angular.json'].find((candidate) =>
-    tree.exists(candidate),
-  );
-  if (!path) return null;
-
-  const buffer = tree.read(path);
-  if (!buffer) return null;
-
+  // `exists` and `read` do not always agree: an Nx host can report a virtual
+  // `angular.json` as present and then fall through to the real filesystem to
+  // read it. An exception escaping here would fail the whole rule chain, so
+  // users would lose the template rewrite as well as the provider wiring.
   try {
+    const path = ['/angular.json', '/.angular.json'].find((candidate) =>
+      tree.exists(candidate),
+    );
+    if (!path) return null;
+
+    const buffer = tree.read(path);
+    if (!buffer) return null;
+
     return JSON.parse(buffer.toString()) as WorkspaceSchema;
   } catch {
     return null;

--- a/libs/transloco/ng-package.json
+++ b/libs/transloco/ng-package.json
@@ -6,6 +6,7 @@
     "CHANGELOG.md",
     "schematics/**/*.json",
     "schematics-core/**/*.json",
+    "migrations/**/*.json",
     "**/files/**/*"
   ],
   "lib": {

--- a/libs/transloco/package.json
+++ b/libs/transloco/package.json
@@ -3,9 +3,27 @@
   "version": "8.4.0",
   "description": "The internationalization (i18n) library for Angular",
   "schematics": "./schematics/collection.json",
+  "ng-update": {
+    "migrations": "./migrations/migration.json",
+    "packageGroup": [
+      "@jsverse/transloco",
+      "@jsverse/transloco-locale",
+      "@jsverse/transloco-messageformat",
+      "@jsverse/transloco-persist-lang",
+      "@jsverse/transloco-persist-translations",
+      "@jsverse/transloco-preload-langs",
+      "@jsverse/transloco-schematics",
+      "@jsverse/transloco-scoped-libs",
+      "@jsverse/transloco-utils",
+      "@jsverse/transloco-optimize",
+      "@jsverse/transloco-validator",
+      "@jsverse/transloco-keys-manager"
+    ]
+  },
   "exports": {
     "./schematics/*": "./schematics/*",
-    "./schematics-core/*": "./schematics-core/*"
+    "./schematics-core/*": "./schematics-core/*",
+    "./migrations/*": "./migrations/*"
   },
   "publishConfig": {
     "access": "public"

--- a/libs/transloco/src/lib/transloco.directive.ts
+++ b/libs/transloco/src/lib/transloco.directive.ts
@@ -70,8 +70,6 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
   @Input('transloco') key: string | undefined;
   @Input('translocoParams') params: HashMap = {};
   @Input('translocoScope') inlineScope: string | undefined;
-  /** @deprecated use prefix instead, will be removed in Transloco v9 */
-  @Input('translocoRead') inlineRead: string | undefined;
   @Input('translocoPrefix') prefix: string | undefined;
   @Input('translocoLang') inlineLang: string | undefined;
   @Input('translocoLoadingTpl') inlineTpl: Content | undefined;
@@ -124,10 +122,7 @@ export class TranslocoDirective implements OnInit, OnDestroy, OnChanges {
         );
         this.strategy === 'attribute'
           ? this.attributeStrategy()
-          : this.structuralStrategy(
-              this.currentLang,
-              this.prefix || this.inlineRead,
-            );
+          : this.structuralStrategy(this.currentLang, this.prefix);
         this.cdr.markForCheck();
         this.initialized = true;
       });

--- a/libs/transloco/tsconfig.schematics.json
+++ b/libs/transloco/tsconfig.schematics.json
@@ -22,6 +22,10 @@
       "@jsverse/transloco-utils": ["../../libs/transloco-utils/src/index.ts"]
     }
   },
-  "include": ["schematics/**/*"],
-  "exclude": ["schematics/*/files/**/*", "schematics/**/*.spec.ts"]
+  "include": ["schematics/**/*", "migrations/**/*"],
+  "exclude": [
+    "schematics/*/files/**/*",
+    "schematics/**/*.spec.ts",
+    "migrations/**/*.spec.ts"
+  ]
 }

--- a/libs/transloco/vitest.config.schematics.ts
+++ b/libs/transloco/vitest.config.schematics.ts
@@ -3,9 +3,9 @@ import { defineNodeProject } from '../../tools/vitest/define-project';
 export default defineNodeProject({
   name: 'transloco-schematics-spec',
   root: __dirname,
-  include: ['schematics/**/*.spec.ts'],
+  include: ['schematics/**/*.spec.ts', 'migrations/**/*.spec.ts'],
   setupFiles: ['../../tools/vitest/setup-schematics.ts'],
   coverageDir: '../../coverage/libs/transloco-schematics-spec',
-  coverageInclude: ['schematics/**/*.ts'],
-  coverageExclude: ['schematics/**/*.spec.ts'],
+  coverageInclude: ['schematics/**/*.ts', 'migrations/**/*.ts'],
+  coverageExclude: ['schematics/**/*.spec.ts', 'migrations/**/*.spec.ts'],
 });

--- a/tools/scripts/append-schematics-npmignore.mts
+++ b/tools/scripts/append-schematics-npmignore.mts
@@ -1,19 +1,14 @@
 /**
- * Appends `.npmignore` overrides so the schematics and schematics-core
- * `package.json` files (needed for `ng add`/`ng generate`) are not stripped
- * from the published `transloco` package.
+ * Appends `.npmignore` overrides so the schematics, schematics-core and
+ * migrations `package.json` files (needed for `ng add`/`ng generate`/`ng update`)
+ * are not stripped from the published `transloco` package.
  */
 import { appendFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-const npmignorePath = join(
-  'dist',
-  'libs',
-  'transloco',
-  '.npmignore',
-);
+const npmignorePath = join('dist', 'libs', 'transloco', '.npmignore');
 
 appendFileSync(
   npmignorePath,
-  '\n!schematics/package.json\n!schematics-core/package.json\n',
+  '\n!schematics/package.json\n!schematics-core/package.json\n!migrations/package.json\n',
 );

--- a/tools/scripts/verify-keys-manager-compat.mts
+++ b/tools/scripts/verify-keys-manager-compat.mts
@@ -209,14 +209,29 @@ const generated = JSON.parse(
   readFileSync(join(project, 'i18n', 'en.json'), 'utf8'),
 );
 const actual = flatten(generated).sort();
-const missing = expected.filter((key) => !actual.includes(key));
 
-if (missing.length) {
-  console.error(
-    `\nMissing ${missing.length} expected key(s): ${missing.join(', ')}`,
-  );
+// Both directions: an AST shim that duplicates a node, or walks into one it
+// should not, adds keys rather than losing them - and a missing-only check
+// would call that a pass.
+const missing = expected.filter((key) => !actual.includes(key));
+const unexpected = actual.filter((key) => !expected.includes(key));
+
+if (missing.length || unexpected.length) {
+  if (missing.length) {
+    console.error(
+      `\nMissing ${missing.length} expected key(s): ${missing.join(', ')}`,
+    );
+  }
+
+  if (unexpected.length) {
+    console.error(
+      `\nExtracted ${unexpected.length} unexpected key(s): ${unexpected.join(', ')}`,
+    );
+  }
+
+  console.error(`Expected:  ${JSON.stringify(expected.slice().sort())}`);
   console.error(`Extracted: ${JSON.stringify(actual)}`);
   process.exit(1);
 }
 
-console.log(`\nAll ${expected.length} expected keys extracted.`);
+console.log(`\nExactly the ${expected.length} expected keys were extracted.`);

--- a/tools/scripts/verify-keys-manager-compat.mts
+++ b/tools/scripts/verify-keys-manager-compat.mts
@@ -1,0 +1,222 @@
+/**
+ * Checks that keys-manager still extracts every key against a given
+ * `@angular/compiler` / `typescript` pair, since the workspace only ever
+ * installs one version of each.
+ *
+ * Packs the built library into a throwaway project rather than swapping the
+ * root dependency: an older `@angular/compiler` breaks the dev toolchain first
+ * (`@analogjs/vite-plugin-angular` needs Angular >=21).
+ *
+ *   nx build transloco-keys-manager
+ *   node tools/scripts/verify-keys-manager-compat.mts --angular=20 --typescript=5.8
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const args = new Map(
+  process.argv
+    .slice(2)
+    .filter((arg) => arg.startsWith('--'))
+    .map((arg) => {
+      const [key, value] = arg.slice(2).split('=');
+
+      return [key, value] as const;
+    }),
+);
+
+const angularVersion = args.get('angular');
+const typescriptVersion = args.get('typescript');
+
+if (!angularVersion || !typescriptVersion) {
+  console.error(
+    'Usage: verify-keys-manager-compat.mts --angular=<range> --typescript=<range>',
+  );
+  process.exit(1);
+}
+
+const repoRoot = process.cwd();
+const distDir = join(repoRoot, 'dist', 'libs', 'transloco-keys-manager');
+
+/**
+ * Every template feature whose AST the extractors walk. `@switch` and the
+ * literal-map pipe params are the two that changed in 21.1; the rest are here
+ * to catch a future reshape of any other block.
+ */
+const TEMPLATE = `
+<ng-container *transloco="let t; prefix: 'home'">
+  @switch (cond) {
+    @case (a) { <p>{{ t('switchCase') }}</p> }
+    @default { <p>{{ t('switchDefault') }}</p> }
+  }
+  @if (x) { <p>{{ t('inIf') }}</p> } @else { <p>{{ t('inElse') }}</p> }
+  @for (i of list; track i) {
+    @switch (i) { @case (a) { <p>{{ t('nestedSwitch') }}</p> } }
+  } @empty { <p>{{ t('inEmpty') }}</p> }
+  @defer (on viewport) { <p>{{ t('inDefer') }}</p> }
+  @placeholder { <p>{{ t('inPlaceholder') }}</p> }
+  @loading { <p>{{ t('inLoading') }}</p> }
+  @error { <p>{{ t('inError') }}</p> }
+  <p>{{ t('plain') }}</p>
+</ng-container>
+<ng-template transloco let-x translocoPrefix="tpl">{{ x('attrForm') }}</ng-template>
+<a [title]="'pipeKey' | transloco:{ a: 'x', b: { c: 1 } }"></a>
+`;
+
+/**
+ * Sharing one `@case` body across several labels is 21.1-only syntax - it is
+ * the reason the AST grew case groups - and is a parse error before that, so it
+ * lives in its own file and is only added where it compiles.
+ */
+const GROUPED_CASES_TEMPLATE = `
+<ng-container *transloco="let t; prefix: 'grouped'">
+  @switch (cond) {
+    @case (a) @case (b) { <p>{{ t('sharedBody') }}</p> }
+    @case (c) { <p>{{ t('ownBody') }}</p> }
+  }
+</ng-container>
+`;
+
+const SOURCE = `
+import { translate, TranslocoService } from '@jsverse/transloco';
+
+export class Greeter {
+  constructor(private service: TranslocoService) {}
+  a() { return translate('tsPure'); }
+  b() { return this.service.translate('tsService'); }
+  c() { return this.service.selectTranslate('tsSelect'); }
+}
+`;
+
+const EXPECTED = [
+  'home.inDefer',
+  'home.inElse',
+  'home.inEmpty',
+  'home.inError',
+  'home.inIf',
+  'home.inLoading',
+  'home.inPlaceholder',
+  'home.nestedSwitch',
+  'home.plain',
+  'home.switchCase',
+  'home.switchDefault',
+  'pipeKey',
+  'tpl.attrForm',
+  'tsPure',
+  'tsSelect',
+  'tsService',
+];
+
+const GROUPED_CASES_EXPECTED = ['grouped.ownBody', 'grouped.sharedBody'];
+
+/** Case groups landed in 21.1. */
+function supportsGroupedCases(version: string): boolean {
+  const [major, minor] = version.split('.').map(Number);
+
+  return major > 21 || (major === 21 && minor >= 1);
+}
+
+function run(command: string, commandArgs: string[], cwd: string) {
+  return execFileSync(command, commandArgs, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    shell: process.platform === 'win32',
+  });
+}
+
+/** Flattens the generated translation file into dot-separated key paths. */
+function flatten(value: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(value).flatMap(([key, entry]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+
+    return entry !== null && typeof entry === 'object'
+      ? flatten(entry as Record<string, unknown>, path)
+      : [path];
+  });
+}
+
+const project = mkdtempSync(join(tmpdir(), 'tkm-compat-'));
+console.log(
+  `Verifying keys-manager against @angular/compiler@${angularVersion} + typescript@${typescriptVersion}`,
+);
+console.log(`Scratch project: ${project}`);
+
+// Pack so the check runs against the published layout, bin included.
+const packOutput = run(
+  'npm',
+  ['pack', distDir, '--pack-destination', project],
+  repoRoot,
+);
+const tarball = join(project, packOutput.trim().split('\n').pop()!);
+
+mkdirSync(join(project, 'src'), { recursive: true });
+writeFileSync(join(project, 'src', 'app.html'), TEMPLATE);
+writeFileSync(join(project, 'src', 'app.ts'), SOURCE);
+writeFileSync(
+  join(project, 'package.json'),
+  JSON.stringify(
+    { name: 'tkm-compat', version: '1.0.0', private: true },
+    null,
+    2,
+  ),
+);
+
+console.log('Installing...');
+run(
+  'npm',
+  [
+    'install',
+    tarball,
+    `@angular/compiler@${angularVersion}`,
+    `typescript@${typescriptVersion}`,
+    '--no-audit',
+    '--no-fund',
+  ],
+  project,
+);
+
+const resolved = (name: string) =>
+  JSON.parse(
+    readFileSync(join(project, 'node_modules', name, 'package.json'), 'utf8'),
+  ).version;
+const resolvedAngular = resolved('@angular/compiler');
+console.log(
+  `Resolved @angular/compiler@${resolvedAngular}, typescript@${resolved('typescript')}`,
+);
+
+// Written after the install so the real resolved version decides, not the range.
+const grouped = supportsGroupedCases(resolvedAngular);
+const expected = [...EXPECTED];
+if (grouped) {
+  writeFileSync(join(project, 'src', 'grouped.html'), GROUPED_CASES_TEMPLATE);
+  expected.push(...GROUPED_CASES_EXPECTED);
+}
+console.log(
+  grouped
+    ? 'Including grouped @case bodies (Angular >=21.1).'
+    : 'Skipping grouped @case bodies - not valid syntax before Angular 21.1.',
+);
+
+run(
+  join(project, 'node_modules', '.bin', 'transloco-keys-manager'),
+  ['extract', '--input', 'src', '--output', 'i18n', '--langs', 'en'],
+  project,
+);
+
+const generated = JSON.parse(
+  readFileSync(join(project, 'i18n', 'en.json'), 'utf8'),
+);
+const actual = flatten(generated).sort();
+const missing = expected.filter((key) => !actual.includes(key));
+
+if (missing.length) {
+  console.error(
+    `\nMissing ${missing.length} expected key(s): ${missing.join(', ')}`,
+  );
+  console.error(`Extracted: ${JSON.stringify(actual)}`);
+  process.exit(1);
+}
+
+console.log(`\nAll ${expected.length} expected keys extracted.`);


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [x] Feature
- [x] CI related changes
- [x] Documentation content changes

## What is the current behavior?

Three separate gaps ahead of the v9 release:

1. `translocoRead` is still present, marked `@deprecated ... will be removed in Transloco v9`.
2. `@jsverse/transloco` ships no `ng-update` migrations collection at all, so none of the v9 breaking changes can be applied automatically.
3. `@jsverse/transloco-keys-manager` declares `@angular/compiler >= 21.1.0` and `typescript >= 5.9.0`, while the runtime packages accept Angular `>=20`. Putting TKM in an update package group would abort `ng update` for anyone on Angular 20.

Issue Number: N/A

## What is the new behavior?

### 1. `fix(keys-manager): support angular 20 and typescript 5.8`

Only one symbol genuinely required Angular 21.1 — `TmplAstSwitchBlockCaseGroup`. `ParenthesizedExpression` has existed since ≤20.0.0, and `@jsverse/angular-utils` peers `>=18.1.0`. The real constraint was two AST **shape** changes in 21.1, so presence checks alone are not enough:

|                  | Angular 20.x – 21.0                       | Angular 21.1+                                   |
| ---------------- | ----------------------------------------- | ----------------------------------------------- |
| `@switch`        | `SwitchBlock.cases`, children on the case | `SwitchBlock.groups`, children on the new group |
| literal map keys | `{ key, quoted }`                         | union tagged with `kind`, to allow spread keys  |

Both are normalized in a new `keys-builder/template/compiler-compat.ts`. It uses a namespace import on purpose: TKM compiles to CJS against an ESM-only `@angular/compiler`, so a named import of a missing symbol is `undefined` and `x instanceof undefined` throws.

On Angular 20 today TKM **crashes** — first at `resolveKeysFromLiteralMap` destructuring an empty filter result, then at the `instanceof`. Verified by stashing the fix, rebuilding, and re-running.

Peers widen to `@angular/compiler >= 20.0.0 < 23.0.0` and `typescript >= 5.8.0 < 7.0.0`. The TypeScript floor is load-bearing: `@angular/compiler-cli@20.0.x` pins `typescript >=5.8 <5.9`, so leaving the peer at `>=5.9` would have re-created the same unsatisfiable-peer abort the compiler widening was meant to remove.

### 2. `feat(transloco): remove deprecated translocoRead input`

Removes the input and its `this.prefix || this.inlineRead` fallback. **Breaking.**

Keys-manager deliberately keeps extracting `translocoRead`, so it still works against codebases that have not migrated.

### 3. `feat(transloco): add ng update migration to v9`

Adds the `ng-update` collection `@jsverse/transloco` never had, plus the packaging to ship it (`exports`, `ng-package.json` assets, `tsconfig.schematics.json`, `.npmignore` overrides). `packageGroup` now covers every published package including keys-manager.

`ng update @jsverse/transloco` will:

- Rename `translocoRead` → `translocoPrefix` in `.html` files and inline `template:` literals, in **both** the attribute form and the `*transloco="…; read: …"` microsyntax. Where an element carries both, the `read` is dropped rather than renamed — `prefix` already won in v8, and renaming would emit a duplicate attribute that fails to parse.
- Add `provideGlobalTranslateFn()` to applications that import `translate`/`translateObject`, restoring the implicit v8 wiring. Libraries are reported instead; projects with no usage are skipped, preserving the SSR/MFE opt-out.
- Report what it cannot fix: the Angular/rxjs floors and the CLI packages' Node `>=22` bump (`ng update` never inspects `engines`).

### 4. `ci(keys-manager): verify angular and typescript ranges`

New `keys-manager-compat` job, wired into the `ci-passed` gate, over four pairs: Angular 20/21.0/21/22 with TypeScript 5.8/5.9/6.0.

Swapping `@angular/compiler` at the workspace root does not work — `@analogjs/vite-plugin-angular` imports `ClassPropertyMapping`, which needs Angular ≥21, so the test tooling breaks before TKM runs. Instead `tools/scripts/verify-keys-manager-compat.mts` packs the built library, installs it into a throwaway project at the target versions and drives the published CLI, asserting all 16 keys still extract. That tests what users install rather than the source tree, and runs locally too.

### 5. `docs: document the v9 breaking changes`

New v9 section in `BREAKING_CHANGES.md`, each entry tied to the commit that introduced it.

## Does this PR introduce a breaking change?

- [x] Yes

`translocoRead` is removed. `ng update @jsverse/transloco` handles it.

The other v9 breaking changes (Angular `>=20`, rxjs, Node `>=22`, `provideGlobalTranslateFn()`) landed in earlier PRs; this one documents them and migrates what can be migrated.

## Other information

**Verification.** Full `ci:test` (14 projects), `ci:lint` (15 projects) and `ci:build` (13 projects) pass. Packaging was checked against the built output — `dist/libs/transloco/migrations/**` ships, `migrations/package.json` survives the `.npmignore` pass, and the compiled factory loads. The migration was smoke-tested against the real keys-manager template fixtures.

**One decision left for the release.** `warn-unsupported-options.ts` tells users an unsupported CLI flag *"will throw an error in the next major version"*, but nothing throws yet — the escalation is still a proposal (`libs/transloco-keys-manager/v9.md`, item 3) needing per-command option schemas. `BREAKING_CHANGES.md` records it as **not implemented** rather than claiming behaviour v9 will not have. Either land it before tagging, or the promise rolls to v10.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated Transloco v9 migrations for template updates and global translation provider configuration.
  - Added migration guidance and compatibility checks for Angular, Node.js, and RxJS requirements.
  - Added Angular 20–22 and TypeScript 5.8–6.x support for Transloco Keys Manager.

- **Breaking Changes**
  - Removed the deprecated `translocoRead` directive input; use `translocoPrefix` instead.
  - Global translation functions now require explicit provider configuration.

- **Bug Fixes**
  - Improved translation-key extraction across supported Angular compiler versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->