### PR TITLE
fix(transloco): stop the schematics build writing into transloco-utils sources

### DIFF
--- a/libs/transloco-utils/.gitignore
+++ b/libs/transloco-utils/.gitignore
@@ -1,2 +1,0 @@
-/src/**/*.js
-/src/**/*.js.map

--- a/libs/transloco/project.json
+++ b/libs/transloco/project.json
@@ -24,6 +24,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
+      "dependsOn": ["^build"],
       "options": {
         "parallel": false,
         "commands": [

--- a/libs/transloco/tsconfig.schematics.json
+++ b/libs/transloco/tsconfig.schematics.json
@@ -18,8 +18,15 @@
     "strictNullChecks": true,
     "target": "es6",
     "types": ["node"],
+    // Resolve to the built declarations, not the sources. Mapping to `.ts`
+    // pulls transloco-utils into this program, and because those files sit
+    // outside `rootDir` their output lands next to the sources
+    // (`libs/transloco-utils/src/*.js|.d.ts`) instead of in `outDir`.
+    // `nx build transloco` builds transloco-utils first via `^build`.
     "paths": {
-      "@jsverse/transloco-utils": ["../../libs/transloco-utils/src/index.ts"]
+      "@jsverse/transloco-utils": [
+        "../../dist/libs/transloco-utils/src/index.d.ts"
+      ]
     }
   },
   "include": ["schematics/**/*"],

--- a/libs/transloco/tsconfig.schematics.json
+++ b/libs/transloco/tsconfig.schematics.json
@@ -18,11 +18,6 @@
     "strictNullChecks": true,
     "target": "es6",
     "types": ["node"],
-    // Resolve to the built declarations, not the sources. Mapping to `.ts`
-    // pulls transloco-utils into this program, and because those files sit
-    // outside `rootDir` their output lands next to the sources
-    // (`libs/transloco-utils/src/*.js|.d.ts`) instead of in `outDir`.
-    // `nx build transloco` builds transloco-utils first via `^build`.
     "paths": {
       "@jsverse/transloco-utils": [
         "../../dist/libs/transloco-utils/src/index.d.ts"


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [x] Build related changes

## What is the current behavior?

`nx build transloco` writes compiler output into another library's source tree:

```
libs/transloco-utils/src/index.d.ts
libs/transloco-utils/src/index.js
libs/transloco-utils/src/index.js.map
libs/transloco-utils/src/lib/transloco-utils.d.ts
libs/transloco-utils/src/lib/transloco-utils.js
libs/transloco-utils/src/lib/transloco-utils.js.map
libs/transloco-utils/src/lib/transloco-utils.types.d.ts
libs/transloco-utils/src/lib/transloco-utils.types.js
libs/transloco-utils/src/lib/transloco-utils.types.js.map
```

`libs/transloco-utils/.gitignore` hid the `.js` and `.js.map` two-thirds of it, so only the three `.d.ts` files ever showed up in `git status` — as untracked files that are easy to commit by accident.

**Cause.** `libs/transloco/tsconfig.schematics.json` maps `@jsverse/transloco-utils` to the library's **sources**:

```json
"rootDir": ".",
"outDir": "../../dist/libs/transloco",
"declaration": true,
"paths": { "@jsverse/transloco-utils": ["../../libs/transloco-utils/src/index.ts"] }
```

`libs/transloco/schematics-core/utils/{schematic,transloco}.ts` import that package, so its `.ts` files join the program. They sit outside `rootDir`, and TypeScript emits an out-of-`rootDir` input **next to its source**, ignoring `outDir` entirely — verified by re-running the old config with `outDir` redirected to `dist/repro-transloco`: the schematics output followed `outDir`, the utils output still landed in `libs/transloco-utils/src`. That rules out fixing this by moving `outDir` or widening `rootDir`.

Issue Number: N/A

## What is the new behavior?

The mapping points at the built declarations instead:

```json
"paths": {
  "@jsverse/transloco-utils": ["../../dist/libs/transloco-utils/src/index.d.ts"]
}
```

TypeScript emits nothing for a `.d.ts` input, so the utils types are read and never compiled.

**Why `dist` is safe to depend on here**

- `libs/transloco/project.json` now declares `"dependsOn": ["^build"]` on the `build` target explicitly. It was already inherited from `nx.json` `targetDefaults`, but it is the ordering contract for the `npx tsc -p libs/transloco/tsconfig.schematics.json` command sitting three lines below it, so it belongs at the point of use.
- The project graph has a static `transloco -> transloco-utils` edge (from the imports above), so `^build` resolves to `transloco-utils:build`.
- `transloco-utils:build` declares `outputs`, so a cache hit restores `dist/libs/transloco-utils` rather than skipping it.
- The guarantee is therefore "current", not merely "present": any change to utils re-runs or re-restores that build before `tsc` runs.
- If the declarations are somehow absent, `tsc` fails loudly with `TS2307` under `noEmitOnError: true` — it cannot fall back to the old behaviour.

Only the build reads this tsconfig (`grep` finds exactly one reference, the build command). Editors, ESLint and Vitest keep resolving utils to source through `tsconfig.base.json`, unchanged.

**Accepted tradeoff:** running `npx tsc -p libs/transloco/tsconfig.schematics.json` by hand, outside Nx, against an empty or stale `dist` now fails or type-checks against stale declarations. Use `nx build transloco`.

`libs/transloco-utils/.gitignore` is deleted. It existed only to hide this emit; with nothing writing there, keeping it would let the `.js` half of a future regression pass silently again.

## Does this PR introduce a breaking change?

- [x] No

`dist/libs/transloco` is byte-identical before and after (`diff -r` against a pre-change build is empty), so the published package is unaffected.

## Other information

**Verification**

- Cold build — `rm -rf dist && npx nx reset && npx nx build transloco`: succeeds, and nothing appears under `libs/transloco-utils/src`, including ignored files (`git status --porcelain --ignored`).
- Failure mode — with `dist/libs/transloco-utils` removed, the bare `tsc` run errors `TS2307` on both importing files and emits nothing.
- Full `ci:build` (13 projects) — no stray files anywhere in `libs/`.
- Full `ci:test` (14 projects) and `ci:lint` (15 projects) pass; `transloco:test-schematics` re-run after the tsconfig change.
- Published output diffed against a baseline build from `master`: identical.

**Isolated, but not fixed here:** `libs/transloco-schematics/tsconfig.schematics.json` carries the same source-mapping landmine, but it is dead config — the project builds with `tsconfig.lib.json`, this file is referenced nowhere, its `include` targets a `schematics/` directory that does not exist, its `outDir` points at `dist/libs/transloco` (the wrong package), and it still sets `enableIvy: false`. It emits nothing today. Worth deleting, but out of scope for this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package build configuration so dependent packages are built in the correct order.
  * Updated package resolution to use compiled type declarations consistently.
  * Adjusted repository settings for generated JavaScript output.
  * No changes to public APIs or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->