### PR TITLE
ci(release): push commit and tag atomically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,10 +198,19 @@ jobs:
 
       # The releases/{version} tag must be on the remote BEFORE the changelog
       # step creates the GitHub release, otherwise the API invents the tag at
-      # the old master HEAD
+      # the old master HEAD.
+      #
+      # --atomic because refs otherwise push independently: a rejected branch
+      # update still leaves the tag behind. That is exactly what the
+      # 9.0.0-alpha.0 run did — master was rejected (GH006) while
+      # releases/9.0.0-alpha.0 landed. master's version therefore never moved,
+      # so the retry recomputed the same version against a tag that already
+      # existed at a different commit, and would have been rejected again as a
+      # non-fast-forward tag update. All-or-nothing keeps a failed release
+      # re-runnable without manual tag cleanup.
       - name: Push commit and tag
         if: ${{ !inputs.dry-run }}
-        run: git push --follow-tags origin HEAD:master
+        run: git push --atomic --follow-tags origin HEAD:master
 
       # Use the app token (not the default GITHUB_TOKEN): nx release changelog
       # both creates the GitHub Release and may push the changelog commit, so it


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] CI related changes

## What is the current behavior?

`Push commit and tag` runs `git push --follow-tags origin HEAD:master`. Refs push independently by default, so a rejected branch update still leaves the tag on the remote.

This is not hypothetical — it happened on the `9.0.0-alpha.0` run ([run 32295879364](https://github.com/jsverse/transloco/actions/runs/32295879364/job/96207497608)):

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - Required status check "CI Passed" is expected.
 * [new tag]           releases/9.0.0-alpha.0 -> releases/9.0.0-alpha.0
 ! [remote rejected]   HEAD -> master (protected branch hook declined)
```

The tag landed, master did not. Since master's `package.json` stayed at 8.4.0, a retry recomputes the *same* version on a *new* commit, and the tag push is then rejected a second time as a non-fast-forward update — the release is wedged until someone manually deletes the remote tag.

Issue Number: N/A

## What is the new behavior?

`git push --atomic --follow-tags origin HEAD:master` — the branch update and the tag either both land or neither does. A failed release stays re-runnable with no manual tag cleanup.

The `--follow-tags` behavior and the ordering requirement (tag must exist on the remote before `nx release changelog` creates the GitHub release) are unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The GH006 rejection itself had a separate root cause — the `jsverse-release-bot` app was not a bypass actor for the required status check. That has been fixed in the repository settings (master migrated from classic branch protection to rulesets, with the app as an `Always allow` bypass actor on the status-check and pull-request rulesets, and the classic protection removed). This PR only addresses the orphan-tag failure mode, which would have applied to any push rejection.

Note that a dry run cannot exercise this change — the step is gated on `if: ${{ !inputs.dry-run }}`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing reliability by ensuring release commits and their tags are pushed together.
  * Prevented partially published releases when a commit or tag push fails.

* **Chores**
  * Updated the release automation process to provide more consistent and dependable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->