### PR TITLE
ci(release): skip gates on dry-run, use client-id input

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,18 @@
+# actionlint validates action inputs against a data set of popular actions that
+# is baked into the binary at build time. As of actionlint 1.7.12 (the version
+# pinned in ci.yml) that snapshot predates `actions/create-github-app-token`
+# gaining the `client-id` input, so it still believes `app-id` is the only —
+# and a required — way to identify the app.
+#
+# The v3 tag we pin declares `client-id` (and marks `app-id` deprecated, which
+# is why the release run logs "Input 'app-id' has been deprecated with message:
+# Use 'client-id' instead"). Both are optional there and the action resolves
+# them as `client-id || app-id`.
+#
+# So these two errors are stale-metadata false positives, scoped as narrowly as
+# possible. Delete this file once an actionlint release refreshes its data set.
+paths:
+  .github/workflows/release.yml:
+    ignore:
+      - 'input "client-id" is not defined in action "actions/create-github-app-token@v3"'
+      - 'missing input "app-id" which is required by action "actions/create-github-app-token@v3"'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,15 @@ concurrency:
 jobs:
   # Real releases are master-only; dry-runs touch nothing remote (publish runs
   # with --dry-run; push/changelog are gated on !inputs.dry-run), so they may
-  # be dispatched from any branch to test the pipeline
+  # be dispatched from any branch to exercise the *release* pipeline — they do
+  # not verify the code, since the gate below is skipped on a dry run.
+  #
+  # Skipped on dry-run: ci.yml already runs lint/test/build/e2e on every PR and
+  # on every push to master, and a dry run only asks "does the release pipeline
+  # work" — nothing it does depends on the code being green. Re-proving it would
+  # be pure latency in front of the steps actually under test.
   gate:
-    if: ${{ github.ref == 'refs/heads/master' || inputs.dry-run }}
+    if: ${{ !inputs.dry-run && github.ref == 'refs/heads/master' }}
     permissions:
       contents: read
     name: ${{ matrix.target }}
@@ -71,7 +77,8 @@ jobs:
   # `playwright` matrix value in lockstep with ci.yml and @playwright/test —
   # see the longer note in ci.yml.
   gate-e2e:
-    if: ${{ github.ref == 'refs/heads/master' || inputs.dry-run }}
+    # Same dry-run skip as `gate` above — see the note there.
+    if: ${{ !inputs.dry-run && github.ref == 'refs/heads/master' }}
     # The workflow-level scope (contents: write + id-token: write) exists for
     # the `release` job's push and OIDC publish. A gate only ever reads.
     permissions:
@@ -100,9 +107,16 @@ jobs:
       - name: Run ci:e2e
         run: npm run ci:e2e
 
+  # `skipped` is an accepted gate result: on a dry run both gates are skipped,
+  # and a bare `needs:` would cascade that skip to this job. `!cancelled()`
+  # still keeps a cancelled run from ever reaching the publish step.
   release:
     needs: [gate, gate-e2e]
-    if: ${{ github.ref == 'refs/heads/master' || inputs.dry-run }}
+    if: >-
+      ${{ !cancelled()
+      && (needs.gate.result == 'success' || needs.gate.result == 'skipped')
+      && (needs.gate-e2e.result == 'success' || needs.gate-e2e.result == 'skipped')
+      && (github.ref == 'refs/heads/master' || inputs.dry-run) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -115,7 +129,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          # `client-id` supersedes the deprecated `app-id` input; the action
+          # forwards either verbatim as the JWT issuer and GitHub accepts the
+          # numeric App ID there, so the existing secret keeps working as-is.
+          client-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           # Least-privilege: the token only needs Contents (push release
           # commit/tag to master + create the GitHub Release). Declaring it


### PR DESCRIPTION
Two independent fixes to the release workflow.

## 1. `app-id` is deprecated — use `client-id`

Release runs log a deprecation warning from the app-token step:

> Warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.

Renamed the input. **The secret reference is deliberately unchanged** (`secrets.RELEASE_APP_ID`): at the pinned `v3` tag the action resolves `getInput("client-id") || getInput("app-id")` and forwards the value verbatim as the JWT issuer, and GitHub accepts the numeric App ID there. So this is behavior-neutral and needs no repo-admin action.

If we later want true Client-ID semantics, that's a separate change: add a `RELEASE_APP_CLIENT_ID` secret and flip the reference.

## 2. Dry runs no longer pay for the CI gates

A dry run only answers "does the release pipeline work" — nothing it does depends on the code being green, and `ci.yml` already runs lint/test/build/e2e on every PR and every push to master. Both gate jobs are now skipped when `dry-run` is set, putting the steps actually under test at the front of the run.

The `release` job needed a matching change: a bare `needs:` cascades a skipped dependency into a skipped dependent, so it now accepts `skipped` as a gate result. `!cancelled()` (rather than `always()`) keeps a cancelled run from ever reaching `npm publish`.

Real releases are unaffected — they stay master-only and fully gated, carried by the trailing `(github.ref == 'refs/heads/master' || inputs.dry-run)` clause.

## Why `.github/actionlint.yaml` is new

`actionlint` is a required check here, and 1.7.12 (the version pinned in `ci.yml`, and the latest release) validates action inputs against a metadata snapshot baked in at build time. That snapshot predates `create-github-app-token` gaining `client-id`, so it rejects the input as undefined and demands the now-optional `app-id`. Without this suppression, change 1 fails CI.

It is scoped to two exact messages on one file, and should be deleted once an actionlint release refreshes its dataset. Note the patterns hardcode `@v3`, so bumping the action's major version will make them stop matching.

## Verification

- `actionlint` clean across all workflows, run against the committed tree
- YAML parses; all three job conditions confirmed to resolve as intended
- `v3`'s `dist/main.cjs` confirmed to contain `getInput("client-id") || getInput("app-id")`
- repo-wide grep confirms `release.yml` is the only app-token usage

Neither workflow change is runtime-testable without a real `workflow_dispatch`; the app-token change is behavior-neutral by construction rather than by test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Release validation now runs only for non-dry-run releases on the `master` branch.
  * Dry-run releases skip validation checks.
  * Releases can proceed when validation checks are skipped, but not after cancellation.
  * Updated GitHub App authentication configuration for reliable release automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->