### PR TITLE
fix(keys-manager): follow-up review fixes for transloco-keys-manager

### DIFF
--- a/libs/transloco-keys-manager/src/index.ts
+++ b/libs/transloco-keys-manager/src/index.ts
@@ -29,10 +29,20 @@ if (help) {
   process.exit();
 }
 
+const inputPaths = config.input
+  ?.split(',')
+  .map((path: string) => path.trim())
+  .filter(Boolean);
+
+if (config.input && !inputPaths.length) {
+  console.error('The "input" option must contain at least one valid path.');
+  process.exit(1);
+}
+
 const resolvedConfig = {
   ...config,
   command: mainOptions.command,
-  ...(config.input ? { input: config.input.split(',') } : {}),
+  ...(inputPaths?.length ? { input: inputPaths } : {}),
 } as Config;
 
 async function run() {
@@ -52,6 +62,7 @@ async function run() {
     }
   } else {
     console.log(`Please provide an action...`);
+    process.exitCode = 1;
   }
 }
 

--- a/libs/transloco-keys-manager/src/index.ts
+++ b/libs/transloco-keys-manager/src/index.ts
@@ -34,12 +34,19 @@ const resolvedConfig = {
   ...(config.input ? { input: config.input.split(',') } : {}),
 } as Config;
 
-if (resolvedConfig.command === 'extract') {
-  warnUnsupportedOptions('extract', config);
-  buildTranslationFiles(resolvedConfig);
-} else if (resolvedConfig.command === 'find') {
-  warnUnsupportedOptions('find', config);
-  findMissingKeys(resolvedConfig);
-} else {
-  console.log(`Please provide an action...`);
+async function run() {
+  if (resolvedConfig.command === 'extract') {
+    warnUnsupportedOptions('extract', config);
+    await buildTranslationFiles(resolvedConfig);
+  } else if (resolvedConfig.command === 'find') {
+    warnUnsupportedOptions('find', config);
+    findMissingKeys(resolvedConfig);
+  } else {
+    console.log(`Please provide an action...`);
+  }
 }
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/libs/transloco-keys-manager/src/index.ts
+++ b/libs/transloco-keys-manager/src/index.ts
@@ -3,6 +3,7 @@ import commandLineArgs from 'command-line-args';
 import commandLineUsage from 'command-line-usage';
 
 import { optionDefinitions, sections } from './lib/cli-options';
+import { getConfig } from './lib/config';
 import { buildTranslationFiles } from './lib/keys-builder';
 import { findMissingKeys } from './lib/keys-detective';
 import { Config } from './lib/types';
@@ -40,7 +41,15 @@ async function run() {
     await buildTranslationFiles(resolvedConfig);
   } else if (resolvedConfig.command === 'find') {
     warnUnsupportedOptions('find', config);
-    findMissingKeys(resolvedConfig);
+    const { hasMissingKeys, hasExtraKeys } = findMissingKeys(resolvedConfig);
+    // Read the resolved config, the flags may come from `transloco.config.js`.
+    const { addMissingKeys, emitErrorOnExtraKeys } = getConfig();
+
+    if (hasMissingKeys && !addMissingKeys) {
+      process.exitCode = 1;
+    } else if (hasExtraKeys && emitErrorOnExtraKeys) {
+      process.exitCode = 2;
+    }
   } else {
     console.log(`Please provide an action...`);
   }

--- a/libs/transloco-keys-manager/src/lib/keys-builder/index.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/index.ts
@@ -27,7 +27,7 @@ export async function buildTranslationFiles(inlineConfig: Config) {
 
   let keysFound = 0;
   for (const [_, scopeKeys] of Object.entries(scopeToKeys)) {
-    keysFound += countKeys(scopeKeys as object);
+    keysFound += countKeys(scopeKeys);
   }
 
   logger.log(

--- a/libs/transloco-keys-manager/src/lib/keys-builder/typescript/index.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/typescript/index.ts
@@ -27,7 +27,7 @@ export function extractTSKeys(config: Config): ExtractionResult {
 const translocoImport = /@(jsverse|ngneat)\/transloco/;
 const translocoKeysManagerImport = /@(jsverse|ngneat)\/transloco-keys-manager/;
 function TSExtractor(config: ExtractorConfig): ScopeMap {
-  const { file, scopes, defaultValue, scopeToKeys } = config;
+  const { file, scopes, defaultValue, scopeToKeys, langs } = config;
   const content = readFile(file);
   const extractors = [];
 
@@ -72,6 +72,7 @@ function TSExtractor(config: ExtractorConfig): ScopeMap {
         key,
         lang,
         scopes,
+        langs,
       );
       addKey({
         scopeAlias,
@@ -106,13 +107,14 @@ function resolveAliasAndKeyFromService(
   key: string,
   scopePath: string,
   scopes: Scopes,
+  langs: string[],
 ): [string, string | null] {
   // It means that it's the global
   if (!scopePath) {
     return [key, null];
   }
 
-  const scopeAlias = resolveScopeAlias({ scopePath, scopes });
+  const scopeAlias = resolveScopeAlias({ scopePath, scopes, langs });
 
-  return [key, scopeAlias];
+  return [key, scopeAlias ?? null];
 }

--- a/libs/transloco-keys-manager/src/lib/keys-builder/utils/extract-keys.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/utils/extract-keys.ts
@@ -10,7 +10,7 @@ import { devlog } from '../../utils/logger';
 import { normalizedGlob } from '../../utils/normalize-glob-path';
 
 export function extractKeys(
-  { input, scopes, defaultValue, files }: Config,
+  { input, scopes, defaultValue, files, langs }: Config,
   fileType: FileType,
   extractor: (config: ExtractorConfig) => ScopeMap,
 ): ExtractionResult {
@@ -22,7 +22,7 @@ export function extractKeys(
 
   for (const file of fileList) {
     devlog('extraction', 'Extracting keys', { file, fileType });
-    scopeToKeys = extractor({ file, defaultValue, scopes, scopeToKeys });
+    scopeToKeys = extractor({ file, defaultValue, scopes, scopeToKeys, langs });
   }
 
   return { scopeToKeys, fileCount: fileList.length };

--- a/libs/transloco-keys-manager/src/lib/keys-builder/utils/resolvers.utils.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/utils/resolvers.utils.ts
@@ -35,14 +35,17 @@ export function resolveAliasAndKey(
  *
  *  scopePath: 'some/nested' => someNested
  *  scopePath: 'some/nested/en' => someNested
+ *  scopePath: 'some/nested/unknown' => undefined
  *
  */
 export function resolveScopeAlias({
   scopePath,
   scopes,
+  langs,
 }: {
   scopePath: string;
   scopes: Scopes;
+  langs: string[];
 }) {
   const scopeAlias = scopes.scopeToAlias[scopePath];
   if (scopeAlias) {
@@ -51,10 +54,18 @@ export function resolveScopeAlias({
 
   // Otherwise we're probably have a language in the scope: some/nested/en
   const splitted = scopePath.split('/');
+  const maybeLang = splitted.at(-1) ?? '';
 
-  // Remove the lang
+  // Only a configured language may be stripped, otherwise we'd resolve an
+  // unrelated path such as 'some/nested/deep' to the 'some/nested' scope.
+  if (!langs.includes(maybeLang)) {
+    return undefined;
+  }
+
   splitted.pop();
 
   const scopePathWithoutLang = splitted.join('/');
-  return scopePathWithoutLang && scopes.scopeToAlias[scopePathWithoutLang];
+  return scopePathWithoutLang
+    ? scopes.scopeToAlias[scopePathWithoutLang]
+    : undefined;
 }

--- a/libs/transloco-keys-manager/src/lib/keys-builder/utils/scope.utils.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/utils/scope.utils.ts
@@ -4,18 +4,6 @@ let scopeToAlias: Scopes['scopeToAlias'] = {};
 let aliasToScope: Scopes['aliasToScope'] = {};
 
 export function addScope(scope: string, alias: string) {
-  // Keep the maps bijective, an overwritten scope or alias must not leave a
-  // stale reverse entry behind.
-  const previousAlias = scopeToAlias[scope];
-  if (previousAlias !== undefined) {
-    delete aliasToScope[previousAlias];
-  }
-
-  const previousScope = aliasToScope[alias];
-  if (previousScope !== undefined) {
-    delete scopeToAlias[previousScope];
-  }
-
   scopeToAlias[scope] = alias;
   aliasToScope[alias] = scope;
 }

--- a/libs/transloco-keys-manager/src/lib/keys-builder/utils/scope.utils.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-builder/utils/scope.utils.ts
@@ -4,6 +4,18 @@ let scopeToAlias: Scopes['scopeToAlias'] = {};
 let aliasToScope: Scopes['aliasToScope'] = {};
 
 export function addScope(scope: string, alias: string) {
+  // Keep the maps bijective, an overwritten scope or alias must not leave a
+  // stale reverse entry behind.
+  const previousAlias = scopeToAlias[scope];
+  if (previousAlias !== undefined) {
+    delete aliasToScope[previousAlias];
+  }
+
+  const previousScope = aliasToScope[alias];
+  if (previousScope !== undefined) {
+    delete scopeToAlias[previousScope];
+  }
+
   scopeToAlias[scope] = alias;
   aliasToScope[alias] = scope;
 }

--- a/libs/transloco-keys-manager/src/lib/keys-detective/build-table.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-detective/build-table.ts
@@ -2,13 +2,13 @@ import chalk from 'chalk';
 import Table from 'cli-table3';
 
 import { messages } from '../messages';
+import { KeysDetectiveResult } from '../types';
 import { getLogger } from '../utils/logger';
 
 import { mapDiffToKeys } from './map-diff-to-keys';
 
 type Params = {
   addMissingKeys: boolean;
-  emitErrorOnExtraKeys: boolean;
   langs: string[];
   diffsPerLang: {
     [lang: string]: {
@@ -22,13 +22,14 @@ export function buildTable({
   langs,
   diffsPerLang,
   addMissingKeys,
-  emitErrorOnExtraKeys,
-}: Params) {
+}: Params): KeysDetectiveResult {
   const logger = getLogger();
-  if (langs.length > 0) {
-    let displayAddedMsg = false;
-    let hasExtraKeys = false;
+  const result: KeysDetectiveResult = {
+    hasMissingKeys: false,
+    hasExtraKeys: false,
+  };
 
+  if (langs.length > 0) {
     logger.success(`\x1b[4m${messages.summary}\x1b[0m\n`);
     const table = new Table({
       style: {
@@ -51,14 +52,14 @@ export function buildTable({
 
       if (hasMissing) {
         row.push(mapDiffToKeys(missing, 'rhs'));
-        displayAddedMsg = true;
+        result.hasMissingKeys = true;
       } else {
         row.push('--');
       }
 
       if (hasExtra) {
         row.push(mapDiffToKeys(extra, 'lhs'));
-        hasExtraKeys = true;
+        result.hasExtraKeys = true;
       } else {
         row.push('--');
       }
@@ -66,20 +67,15 @@ export function buildTable({
     }
 
     logger.log(table.toString());
-    if (displayAddedMsg) {
-      if (addMissingKeys) {
-        logger.success(`Added all missing keys\n`);
-      } else {
-        process.exit(1);
-      }
-    }
 
-    if (hasExtraKeys && emitErrorOnExtraKeys) {
-      process.exit(2);
+    if (result.hasMissingKeys && addMissingKeys) {
+      logger.success(`Added all missing keys\n`);
     }
   } else {
     logger.log(`\n🎉 ${messages.noMissing} 🎉\n`);
   }
 
   logger.log('\n');
+
+  return result;
 }

--- a/libs/transloco-keys-manager/src/lib/keys-detective/build-table.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-detective/build-table.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import Table from 'cli-table3';
+import type { DiffDeleted, DiffNew } from 'deep-diff';
 
 import { messages } from '../messages';
 import { KeysDetectiveResult } from '../types';
@@ -12,8 +13,8 @@ type Params = {
   langs: string[];
   diffsPerLang: {
     [lang: string]: {
-      missing: any[];
-      extra: any[];
+      missing: Array<DiffNew<any>>;
+      extra: Array<DiffDeleted<any>>;
     };
   };
 };
@@ -41,7 +42,7 @@ export function buildTable({
     });
 
     for (let i = 0; i < langs.length; i++) {
-      const row: any = [];
+      const row: string[] = [];
       const { missing, extra } = diffsPerLang[langs[i]];
       const hasMissing = missing.length > 0;
       const hasExtra = extra.length > 0;

--- a/libs/transloco-keys-manager/src/lib/keys-detective/compare-keys-to-files.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-detective/compare-keys-to-files.ts
@@ -1,11 +1,13 @@
 import { getGlobalConfig } from '@jsverse/transloco-utils';
 import type { DiffDeleted, DiffNew } from 'deep-diff';
 import df from 'deep-diff';
-import { flatten, unflatten } from 'flat';
+import { flatten } from 'flat';
 
+import { createTranslation } from '../keys-builder/utils/create-translation';
+import { getCurrentTranslation } from '../keys-builder/utils/get-current-translation';
 import { messages } from '../messages';
 import { Config, KeysDetectiveResult, ScopeMap } from '../types';
-import { readFile, writeFile } from '../utils/file.utils';
+import { writeFile } from '../utils/file.utils';
 import { getLogger } from '../utils/logger';
 import { getScopeAndLangFromPath } from '../utils/path.utils';
 import { normalizedGlob } from '../utils/normalize-glob-path';
@@ -22,7 +24,7 @@ interface Result {
 
 interface CompareKeysOptions extends Pick<
   Config,
-  'unflat' | 'fileFormat' | 'addMissingKeys' | 'translationsPath'
+  'fileFormat' | 'addMissingKeys' | 'translationsPath'
 > {
   scopeToKeys: ScopeMap;
 }
@@ -32,7 +34,6 @@ export function compareKeysToFiles({
   translationsPath,
   addMissingKeys,
   fileFormat,
-  unflat,
 }: CompareKeysOptions): KeysDetectiveResult {
   const logger = getLogger();
   logger.startSpinner(`${messages.checkMissing} ✨`);
@@ -104,7 +105,7 @@ export function compareKeysToFiles({
         translationsPath: baseFilesPath,
         fileFormat,
       });
-      const translation = readFile(filePath, { parse: true });
+      const translation = getCurrentTranslation({ path: filePath, fileFormat });
       // We always build the keys flatten, so we need to make sure we compare to a flat file
       const flat = flatten<Record<string, any>, Record<string, string>>(
         translation,
@@ -138,7 +139,16 @@ export function compareKeysToFiles({
         }
 
         if (addMissingKeys) {
-          writeFile(filePath, unflat ? unflatten(translation) : translation);
+          writeFile(
+            filePath,
+            createTranslation({
+              currentTranslation: {},
+              translation,
+              replace: true,
+              removeExtraKeys: false,
+              fileFormat,
+            }),
+          );
         }
       }
     }

--- a/libs/transloco-keys-manager/src/lib/keys-detective/compare-keys-to-files.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-detective/compare-keys-to-files.ts
@@ -54,9 +54,14 @@ export function compareKeysToFiles({
 
   const result: Result[] = [];
   const scopePaths = getGlobalConfig().scopePathMap || {};
+  const cache: Record<string, boolean> = {};
+
   for (const [scope, path] of Object.entries(scopePaths)) {
     const keys = scopeToKeys[scope];
     if (keys) {
+      // Scopes with an explicit path must not be picked up again from the
+      // default translations folder.
+      cache[scope] = true;
       const res: Omit<Result, 'files'> = {
         keys,
         scope,
@@ -68,7 +73,6 @@ export function compareKeysToFiles({
       });
     }
   }
-  const cache: Record<string, boolean> = {};
 
   for (const filePath of translationFiles) {
     const { scope = '__global' } = getScopeAndLangFromPath({

--- a/libs/transloco-keys-manager/src/lib/keys-detective/compare-keys-to-files.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-detective/compare-keys-to-files.ts
@@ -4,7 +4,7 @@ import df from 'deep-diff';
 import { flatten, unflatten } from 'flat';
 
 import { messages } from '../messages';
-import { Config, ScopeMap } from '../types';
+import { Config, KeysDetectiveResult, ScopeMap } from '../types';
 import { readFile, writeFile } from '../utils/file.utils';
 import { getLogger } from '../utils/logger';
 import { getScopeAndLangFromPath } from '../utils/path.utils';
@@ -22,11 +22,7 @@ interface Result {
 
 interface CompareKeysOptions extends Pick<
   Config,
-  | 'unflat'
-  | 'fileFormat'
-  | 'addMissingKeys'
-  | 'emitErrorOnExtraKeys'
-  | 'translationsPath'
+  'unflat' | 'fileFormat' | 'addMissingKeys' | 'translationsPath'
 > {
   scopeToKeys: ScopeMap;
 }
@@ -35,10 +31,9 @@ export function compareKeysToFiles({
   scopeToKeys,
   translationsPath,
   addMissingKeys,
-  emitErrorOnExtraKeys,
   fileFormat,
   unflat,
-}: CompareKeysOptions) {
+}: CompareKeysOptions): KeysDetectiveResult {
   const logger = getLogger();
   logger.startSpinner(`${messages.checkMissing} ✨`);
 
@@ -156,10 +151,9 @@ export function compareKeysToFiles({
     return missing.length || extra.length;
   });
 
-  buildTable({
+  return buildTable({
     langs,
     diffsPerLang,
     addMissingKeys,
-    emitErrorOnExtraKeys,
   });
 }

--- a/libs/transloco-keys-manager/src/lib/keys-detective/index.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-detective/index.ts
@@ -30,13 +30,12 @@ export function findMissingKeys(inlineConfig: Config): KeysDetectiveResult {
   const result = buildKeys(config);
   logger.success(`${messages.extract} 🗝`);
 
-  const { addMissingKeys, unflat } = config;
+  const { addMissingKeys } = config;
 
   return compareKeysToFiles({
     scopeToKeys: result.scopeToKeys,
     translationsPath,
     addMissingKeys,
     fileFormat,
-    unflat,
   });
 }

--- a/libs/transloco-keys-manager/src/lib/keys-detective/index.ts
+++ b/libs/transloco-keys-manager/src/lib/keys-detective/index.ts
@@ -1,14 +1,14 @@
 import { setConfig } from '../config';
 import { buildKeys } from '../keys-builder/build-keys';
 import { messages } from '../messages';
-import { Config } from '../types';
+import { Config, KeysDetectiveResult } from '../types';
 import { getLogger } from '../utils/logger';
 import { resolveConfig } from '../utils/resolve-config';
 
 import { compareKeysToFiles } from './compare-keys-to-files';
 import { getTranslationFilesPath } from './get-translation-files-path';
 
-export function findMissingKeys(inlineConfig: Config) {
+export function findMissingKeys(inlineConfig: Config): KeysDetectiveResult {
   const logger = getLogger();
   const config = resolveConfig(inlineConfig);
   setConfig(config);
@@ -21,7 +21,7 @@ export function findMissingKeys(inlineConfig: Config) {
 
   if (translationFiles.length === 0) {
     console.log('No translation files found.');
-    return;
+    return { hasMissingKeys: false, hasExtraKeys: false };
   }
 
   logger.log('\n 🕵 🔎', `\x1b[4m${messages.startSearch}\x1b[0m`, '🔍 🕵\n');
@@ -30,12 +30,12 @@ export function findMissingKeys(inlineConfig: Config) {
   const result = buildKeys(config);
   logger.success(`${messages.extract} 🗝`);
 
-  const { addMissingKeys, emitErrorOnExtraKeys, unflat } = config;
-  compareKeysToFiles({
+  const { addMissingKeys, unflat } = config;
+
+  return compareKeysToFiles({
     scopeToKeys: result.scopeToKeys,
     translationsPath,
     addMissingKeys,
-    emitErrorOnExtraKeys,
     fileFormat,
     unflat,
   });

--- a/libs/transloco-keys-manager/src/lib/marker.ts
+++ b/libs/transloco-keys-manager/src/lib/marker.ts
@@ -1,15 +1,22 @@
 /**
+ * Mirrors transloco's `HashMap`, declared locally to avoid a dependency on
+ * `@jsverse/transloco`. It must stay as permissive as the `translate` params,
+ * otherwise a `translate` call could not be swapped for a `marker` one.
+ */
+type MarkerParams = Record<string, any>;
+
+/**
  * This function provides the capability to mark translation keys for automatic extraction with transloco.
  * If you want to extract some standalone strings that are not part of any translation call you can wrap them with the marker function to tell the keys manager to extract them.
  * The function will simply return the first "key" argument passed into it.
  *
  * @param key The translation key to extract.
- * @param params This parameter does nothing, but is required for compatipility reasons.
+ * @param params This parameter does nothing, but is required for compatibility reasons.
  * @param scope The scope to when extracting the translation key.
  */
 export function marker<T extends string | string[]>(
   key: T,
-  params?: undefined,
+  params?: MarkerParams,
   scope?: string,
 ): T {
   return key;

--- a/libs/transloco-keys-manager/src/lib/tests/build-table.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/build-table.spec.ts
@@ -21,7 +21,6 @@ vi.mock('../keys-detective/map-diff-to-keys', () => ({
 describe('buildTable', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
     vi.mocked(getLogger().log).mockClear();
     vi.mocked(getLogger().success).mockClear();
   });
@@ -29,22 +28,22 @@ describe('buildTable', () => {
   it('should log no missing keys when langs is empty', () => {
     const logger = getLogger();
 
-    buildTable({
+    const result = buildTable({
       langs: [],
       diffsPerLang: {},
       addMissingKeys: false,
-      emitErrorOnExtraKeys: false,
     });
 
     expect(logger.log).toHaveBeenCalledWith(
       expect.stringContaining('No missing keys were found'),
     );
+    expect(result).toEqual({ hasMissingKeys: false, hasExtraKeys: false });
   });
 
   it('should display "--" for missing column when no missing keys', () => {
     const logger = getLogger();
 
-    buildTable({
+    const result = buildTable({
       langs: ['en'],
       diffsPerLang: {
         en: {
@@ -53,17 +52,16 @@ describe('buildTable', () => {
         },
       },
       addMissingKeys: false,
-      emitErrorOnExtraKeys: false,
     });
 
-    expect(process.exit).not.toHaveBeenCalled();
+    expect(result).toEqual({ hasMissingKeys: false, hasExtraKeys: true });
     expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('--'));
   });
 
   it('should display "--" for extra column when no extra keys', () => {
     const logger = getLogger();
 
-    buildTable({
+    const result = buildTable({
       langs: ['en'],
       diffsPerLang: {
         en: {
@@ -72,15 +70,14 @@ describe('buildTable', () => {
         },
       },
       addMissingKeys: true,
-      emitErrorOnExtraKeys: false,
     });
 
-    expect(process.exit).not.toHaveBeenCalled();
+    expect(result).toEqual({ hasMissingKeys: true, hasExtraKeys: false });
     expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('--'));
   });
 
-  it('should call process.exit(1) when missing keys exist and addMissingKeys is false', () => {
-    buildTable({
+  it('should report missing keys regardless of addMissingKeys', () => {
+    const result = buildTable({
       langs: ['en'],
       diffsPerLang: {
         en: {
@@ -89,19 +86,35 @@ describe('buildTable', () => {
         },
       },
       addMissingKeys: false,
-      emitErrorOnExtraKeys: false,
     });
 
-    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(result).toEqual({ hasMissingKeys: true, hasExtraKeys: false });
+  });
+
+  /**
+   * The reporting used to `process.exit(1)` before the extra keys were
+   * evaluated, so both statuses must now be reported to the caller, which
+   * decides on the exit code.
+   */
+  it('should report both statuses when missing and extra keys exist', () => {
+    const result = buildTable({
+      langs: ['en'],
+      diffsPerLang: {
+        en: {
+          missing: [{ kind: 'N', path: ['key'], rhs: 'val' }],
+          extra: [{ kind: 'D', path: ['old.key'], lhs: 'val' }],
+        },
+      },
+      addMissingKeys: false,
+    });
+
+    expect(result).toEqual({ hasMissingKeys: true, hasExtraKeys: true });
   });
 
   it('should log success when missing keys exist and addMissingKeys is true', () => {
     const logger = getLogger();
-    const exitSpy = vi
-      .spyOn(process, 'exit')
-      .mockImplementation((() => {}) as any);
 
-    buildTable({
+    const result = buildTable({
       langs: ['en'],
       diffsPerLang: {
         en: {
@@ -110,22 +123,17 @@ describe('buildTable', () => {
         },
       },
       addMissingKeys: true,
-      emitErrorOnExtraKeys: false,
     });
 
     expect(logger.success).toHaveBeenCalledWith(
       expect.stringContaining('Added all missing keys'),
     );
-    expect(exitSpy).not.toHaveBeenCalled();
-    exitSpy.mockRestore();
+    // The status describes the diff, whether it is an error is up to the caller.
+    expect(result).toEqual({ hasMissingKeys: true, hasExtraKeys: false });
   });
 
-  it('should call process.exit(2) when extra keys exist and emitErrorOnExtraKeys is true', () => {
-    const exitSpy = vi
-      .spyOn(process, 'exit')
-      .mockImplementation((() => {}) as any);
-
-    buildTable({
+  it('should report extra keys regardless of emitErrorOnExtraKeys', () => {
+    const result = buildTable({
       langs: ['en'],
       diffsPerLang: {
         en: {
@@ -134,19 +142,13 @@ describe('buildTable', () => {
         },
       },
       addMissingKeys: false,
-      emitErrorOnExtraKeys: true,
     });
 
-    expect(exitSpy).toHaveBeenCalledWith(2);
-    exitSpy.mockRestore();
+    expect(result).toEqual({ hasMissingKeys: false, hasExtraKeys: true });
   });
 
   it('should skip langs with no missing and no extra keys', () => {
-    const exitSpy = vi
-      .spyOn(process, 'exit')
-      .mockImplementation((() => {}) as any);
-
-    buildTable({
+    const result = buildTable({
       langs: ['en', 'fr'],
       diffsPerLang: {
         en: { missing: [], extra: [] },
@@ -156,10 +158,8 @@ describe('buildTable', () => {
         },
       },
       addMissingKeys: true,
-      emitErrorOnExtraKeys: false,
     });
 
-    expect(exitSpy).not.toHaveBeenCalled();
-    exitSpy.mockRestore();
+    expect(result).toEqual({ hasMissingKeys: true, hasExtraKeys: false });
   });
 });

--- a/libs/transloco-keys-manager/src/lib/tests/build-table.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/build-table.spec.ts
@@ -18,6 +18,9 @@ vi.mock('../keys-detective/map-diff-to-keys', () => ({
   ),
 }));
 
+const missingKey = { kind: 'N', path: ['key'], rhs: 'val' } as any;
+const extraKey = { kind: 'D', path: ['old.key'], lhs: 'val' } as any;
+
 describe('buildTable', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -25,7 +28,7 @@ describe('buildTable', () => {
     vi.mocked(getLogger().success).mockClear();
   });
 
-  it('should log no missing keys when langs is empty', () => {
+  it('given no langs, when the table is built, then it should log that no keys are missing', () => {
     const logger = getLogger();
 
     const result = buildTable({
@@ -40,17 +43,13 @@ describe('buildTable', () => {
     expect(result).toEqual({ hasMissingKeys: false, hasExtraKeys: false });
   });
 
-  it('should display "--" for missing column when no missing keys', () => {
+  it('given only extra keys, when the table is built, then the missing column should show "--"', () => {
     const logger = getLogger();
+    const diffsPerLang = { en: { missing: [], extra: [extraKey] } };
 
     const result = buildTable({
       langs: ['en'],
-      diffsPerLang: {
-        en: {
-          missing: [],
-          extra: [{ kind: 'D', path: ['unused.key'], lhs: 'val' }],
-        },
-      },
+      diffsPerLang,
       addMissingKeys: false,
     });
 
@@ -58,17 +57,13 @@ describe('buildTable', () => {
     expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('--'));
   });
 
-  it('should display "--" for extra column when no extra keys', () => {
+  it('given only missing keys, when the table is built, then the extra column should show "--"', () => {
     const logger = getLogger();
+    const diffsPerLang = { en: { missing: [missingKey], extra: [] } };
 
     const result = buildTable({
       langs: ['en'],
-      diffsPerLang: {
-        en: {
-          missing: [{ kind: 'N', path: ['new.key'], rhs: 'val' }],
-          extra: [],
-        },
-      },
+      diffsPerLang,
       addMissingKeys: true,
     });
 
@@ -76,15 +71,12 @@ describe('buildTable', () => {
     expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('--'));
   });
 
-  it('should report missing keys regardless of addMissingKeys', () => {
+  it('given missing keys and addMissingKeys is false, when the table is built, then it should still report them', () => {
+    const diffsPerLang = { en: { missing: [missingKey], extra: [] } };
+
     const result = buildTable({
       langs: ['en'],
-      diffsPerLang: {
-        en: {
-          missing: [{ kind: 'N', path: ['key'], rhs: 'val' }],
-          extra: [],
-        },
-      },
+      diffsPerLang,
       addMissingKeys: false,
     });
 
@@ -96,32 +88,25 @@ describe('buildTable', () => {
    * evaluated, so both statuses must now be reported to the caller, which
    * decides on the exit code.
    */
-  it('should report both statuses when missing and extra keys exist', () => {
+  it('given both missing and extra keys, when the table is built, then both statuses should be reported', () => {
+    const diffsPerLang = { en: { missing: [missingKey], extra: [extraKey] } };
+
     const result = buildTable({
       langs: ['en'],
-      diffsPerLang: {
-        en: {
-          missing: [{ kind: 'N', path: ['key'], rhs: 'val' }],
-          extra: [{ kind: 'D', path: ['old.key'], lhs: 'val' }],
-        },
-      },
+      diffsPerLang,
       addMissingKeys: false,
     });
 
     expect(result).toEqual({ hasMissingKeys: true, hasExtraKeys: true });
   });
 
-  it('should log success when missing keys exist and addMissingKeys is true', () => {
+  it('given missing keys and addMissingKeys is true, when the table is built, then it should log success', () => {
     const logger = getLogger();
+    const diffsPerLang = { en: { missing: [missingKey], extra: [] } };
 
     const result = buildTable({
       langs: ['en'],
-      diffsPerLang: {
-        en: {
-          missing: [{ kind: 'N', path: ['key'], rhs: 'val' }],
-          extra: [],
-        },
-      },
+      diffsPerLang,
       addMissingKeys: true,
     });
 
@@ -132,31 +117,27 @@ describe('buildTable', () => {
     expect(result).toEqual({ hasMissingKeys: true, hasExtraKeys: false });
   });
 
-  it('should report extra keys regardless of emitErrorOnExtraKeys', () => {
+  it('given extra keys, when the table is built, then it should report them without any error policy', () => {
+    const diffsPerLang = { en: { missing: [], extra: [extraKey] } };
+
     const result = buildTable({
       langs: ['en'],
-      diffsPerLang: {
-        en: {
-          missing: [],
-          extra: [{ kind: 'D', path: ['old.key'], lhs: 'val' }],
-        },
-      },
+      diffsPerLang,
       addMissingKeys: false,
     });
 
     expect(result).toEqual({ hasMissingKeys: false, hasExtraKeys: true });
   });
 
-  it('should skip langs with no missing and no extra keys', () => {
+  it('given a lang with no differences, when the table is built, then it should be skipped', () => {
+    const diffsPerLang = {
+      en: { missing: [], extra: [] },
+      fr: { missing: [missingKey], extra: [] },
+    };
+
     const result = buildTable({
       langs: ['en', 'fr'],
-      diffsPerLang: {
-        en: { missing: [], extra: [] },
-        fr: {
-          missing: [{ kind: 'N', path: ['key'], rhs: 'val' }],
-          extra: [],
-        },
-      },
+      diffsPerLang,
       addMissingKeys: true,
     });
 

--- a/libs/transloco-keys-manager/src/lib/tests/buildTranslationFiles/config-options/remove-extra-keys/remove-extra-keys-spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/buildTranslationFiles/config-options/remove-extra-keys/remove-extra-keys-spec.ts
@@ -182,5 +182,61 @@ export function testRemoveExtraKeysConfig(fileFormat: Config['fileFormat']) {
         });
       },
     );
+
+    /**
+     * The POT counterpart of the nested-translation guard above. A POT file is
+     * always flat, so the dotted msgids are what a nested JSON file would have
+     * been. The extra keys cleanup must still match them against the flat
+     * extracted keys instead of wiping the file.
+     */
+    describe.runIf(fileFormat === 'pot')(
+      'with dotted msgids and unflat = false',
+      () => {
+        const enPath = nodePath.join(
+          sourceRoot,
+          type,
+          'i18n',
+          `en.${fileFormat}`,
+        );
+
+        it('should drop only the extra keys and keep the existing translations', () => {
+          fs.copyFileSync(missingKeyTpl, testHtmlFile);
+          const entries: Record<string, string> = {
+            '1': 'translated 1',
+            '2': 'translated 2',
+            'group1.2': 'translated group1.2',
+            'group2.1': 'translated group2.1',
+            'group3.2': 'translated group3.2',
+          };
+          fs.outputFileSync(
+            enPath,
+            `msgid ""\nmsgstr ""\n\n${Object.entries(entries)
+              .map(
+                ([msgid, msgstr]) => `msgid "${msgid}"\nmsgstr "${msgstr}"\n`,
+              )
+              .join('\n')}`,
+          );
+
+          buildTranslationFiles({
+            ...buildConfig({ type, config: { unflat: false, fileFormat } }),
+            removeExtraKeys: true,
+          });
+
+          const translation = getCurrentTranslation({
+            path: enPath,
+            fileFormat,
+          });
+
+          expect(translation).toMatchObject({
+            '2': 'translated 2',
+            'group1.2': 'translated group1.2',
+            'group3.2': 'translated group3.2',
+          });
+          // `1` and `group2.1` are no longer used
+          expect(translation).not.toHaveProperty('1');
+          expect(translation).not.toHaveProperty(['group2.1']);
+        });
+      },
+    );
   });
 }

--- a/libs/transloco-keys-manager/src/lib/tests/compare-keys-to-files.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/compare-keys-to-files.spec.ts
@@ -57,7 +57,6 @@ describe('compareKeysToFiles', () => {
       scopeToKeys: { __global: { key: 'value' } },
       translationsPath: '/tmp/i18n',
       addMissingKeys: false,
-      emitErrorOnExtraKeys: false,
       fileFormat: 'json',
       unflat: false,
     });
@@ -82,7 +81,6 @@ describe('compareKeysToFiles', () => {
       scopeToKeys: { __global: { key: 'value' } },
       translationsPath: '/tmp/i18n',
       addMissingKeys: false,
-      emitErrorOnExtraKeys: false,
       fileFormat: 'json',
       unflat: false,
     });
@@ -103,7 +101,6 @@ describe('compareKeysToFiles', () => {
       scopeToKeys: { __global: { existing: 'val', newKey: 'new' } },
       translationsPath: '/tmp/i18n',
       addMissingKeys: true,
-      emitErrorOnExtraKeys: false,
       fileFormat: 'json',
       unflat: false,
     });
@@ -128,7 +125,6 @@ describe('compareKeysToFiles', () => {
       scopeToKeys: { __global: { key: 'value' } },
       translationsPath: '/tmp/i18n',
       addMissingKeys: false,
-      emitErrorOnExtraKeys: false,
       fileFormat: 'json',
       unflat: false,
     });
@@ -159,7 +155,6 @@ describe('compareKeysToFiles', () => {
       },
       translationsPath: '/tmp/i18n',
       addMissingKeys: false,
-      emitErrorOnExtraKeys: false,
       fileFormat: 'json',
       unflat: false,
     });
@@ -191,7 +186,6 @@ describe('compareKeysToFiles', () => {
       scopeToKeys: { __global: { 'a.b': 'value' } },
       translationsPath: '/tmp/i18n',
       addMissingKeys: true,
-      emitErrorOnExtraKeys: false,
       fileFormat: 'json',
       unflat: true,
     });

--- a/libs/transloco-keys-manager/src/lib/tests/compare-keys-to-files.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/compare-keys-to-files.spec.ts
@@ -167,7 +167,7 @@ describe('compareKeysToFiles', () => {
     );
   });
 
-  it('should unflatten translation before writing when unflat is true', () => {
+  it('given unflat is true, when the missing keys are written, then the translation should be unflattened', () => {
     unflat = true;
     mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/en.json']);
     mockGetCurrentTranslation.mockReturnValue({});
@@ -189,7 +189,7 @@ describe('compareKeysToFiles', () => {
    * JSON, so `find --file-format pot` crashed on the first `.pot` file.
    */
   describe('when the file format is pot', () => {
-    it('should parse the translation files as pot', () => {
+    it('given a pot translation file, when the keys are compared, then it should be parsed as pot', () => {
       mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/en.pot']);
       mockGetCurrentTranslation.mockReturnValue({ 'existing.key': 'Existing' });
       mockNormalizedGlob.mockReturnValue(['/tmp/i18n/en.pot']);
@@ -218,7 +218,7 @@ describe('compareKeysToFiles', () => {
       );
     });
 
-    it('should write the missing keys back as pot', () => {
+    it('given addMissingKeys is true, when the missing keys are written, then the file should stay pot', () => {
       mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/en.pot']);
       mockGetCurrentTranslation.mockReturnValue({ 'existing.key': 'Existing' });
       mockNormalizedGlob.mockReturnValue(['/tmp/i18n/en.pot']);

--- a/libs/transloco-keys-manager/src/lib/tests/compare-keys-to-files.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/compare-keys-to-files.spec.ts
@@ -3,7 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { compareKeysToFiles } from '../keys-detective/compare-keys-to-files';
 import { buildTable } from '../keys-detective/build-table';
 import { normalizedGlob } from '../utils/normalize-glob-path';
-import { readFile, writeFile } from '../utils/file.utils';
+import { writeFile } from '../utils/file.utils';
+import { getCurrentTranslation } from '../keys-builder/utils/get-current-translation';
 import { getTranslationFilesPath } from '../keys-detective/get-translation-files-path';
 
 vi.mock('../utils/logger', () => ({
@@ -27,8 +28,16 @@ vi.mock('../keys-detective/get-translation-files-path', () => ({
 }));
 
 vi.mock('../utils/file.utils', () => ({
-  readFile: vi.fn(() => ({})),
   writeFile: vi.fn(),
+}));
+
+vi.mock('../keys-builder/utils/get-current-translation', () => ({
+  getCurrentTranslation: vi.fn(() => ({})),
+}));
+
+let unflat = false;
+vi.mock('../config', () => ({
+  getConfig: () => ({ unflat, sort: false }),
 }));
 
 vi.mock('@jsverse/transloco-utils', () => ({
@@ -38,18 +47,16 @@ vi.mock('@jsverse/transloco-utils', () => ({
 describe('compareKeysToFiles', () => {
   const mockBuildTable = vi.mocked(buildTable);
   const mockNormalizedGlob = vi.mocked(normalizedGlob);
-  const mockReadFile = vi.mocked(readFile);
+  const mockGetCurrentTranslation = vi.mocked(getCurrentTranslation);
   const mockWriteFile = vi.mocked(writeFile);
   const mockGetTranslationFilesPath = vi.mocked(getTranslationFilesPath);
 
   beforeEach(() => {
     vi.clearAllMocks();
+    unflat = false;
     mockNormalizedGlob.mockReturnValue([]);
     mockGetTranslationFilesPath.mockReturnValue([]);
-    mockReadFile.mockImplementation(((path: string, opts?: any) => {
-      if (opts?.parse) return {};
-      return '{}';
-    }) as any);
+    mockGetCurrentTranslation.mockReturnValue({});
   });
 
   it('should call buildTable with empty langs when no translation files', () => {
@@ -58,7 +65,6 @@ describe('compareKeysToFiles', () => {
       translationsPath: '/tmp/i18n',
       addMissingKeys: false,
       fileFormat: 'json',
-      unflat: false,
     });
 
     expect(mockBuildTable).toHaveBeenCalledWith(
@@ -71,10 +77,7 @@ describe('compareKeysToFiles', () => {
       '/tmp/i18n/en.json',
       '/tmp/i18n/fr.json',
     ]);
-    mockReadFile.mockImplementation(((path: string, opts?: any) => {
-      if (opts?.parse) return { key: 'value' };
-      return '{"key":"value"}';
-    }) as any);
+    mockGetCurrentTranslation.mockReturnValue({ key: 'value' });
     mockNormalizedGlob.mockReturnValue(['/tmp/i18n/en.json']);
 
     compareKeysToFiles({
@@ -82,7 +85,6 @@ describe('compareKeysToFiles', () => {
       translationsPath: '/tmp/i18n',
       addMissingKeys: false,
       fileFormat: 'json',
-      unflat: false,
     });
 
     // normalizedGlob called only once for __global scope (second file same scope = cached)
@@ -91,10 +93,7 @@ describe('compareKeysToFiles', () => {
 
   it('should detect missing keys and add them when addMissingKeys is true', () => {
     mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/en.json']);
-    mockReadFile.mockImplementation(((path: string, opts?: any) => {
-      if (opts?.parse) return { existing: 'val' };
-      return '{"existing":"val"}';
-    }) as any);
+    mockGetCurrentTranslation.mockReturnValue({ existing: 'val' });
     mockNormalizedGlob.mockReturnValue(['/tmp/i18n/en.json']);
 
     compareKeysToFiles({
@@ -102,7 +101,6 @@ describe('compareKeysToFiles', () => {
       translationsPath: '/tmp/i18n',
       addMissingKeys: true,
       fileFormat: 'json',
-      unflat: false,
     });
 
     expect(mockWriteFile).toHaveBeenCalled();
@@ -115,10 +113,10 @@ describe('compareKeysToFiles', () => {
 
   it('should exclude comment deletions from extra keys', () => {
     mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/en.json']);
-    mockReadFile.mockImplementation(((path: string, opts?: any) => {
-      if (opts?.parse) return { key: 'value', 'key.comment': 'a comment' };
-      return '{}';
-    }) as any);
+    mockGetCurrentTranslation.mockReturnValue({
+      key: 'value',
+      'key.comment': 'a comment',
+    });
     mockNormalizedGlob.mockReturnValue(['/tmp/i18n/en.json']);
 
     compareKeysToFiles({
@@ -126,7 +124,6 @@ describe('compareKeysToFiles', () => {
       translationsPath: '/tmp/i18n',
       addMissingKeys: false,
       fileFormat: 'json',
-      unflat: false,
     });
 
     expect(mockBuildTable).toHaveBeenCalledWith(
@@ -142,10 +139,7 @@ describe('compareKeysToFiles', () => {
 
   it('should namespace missing keys under the scope path (e.g. admin/en) for scoped translation files', () => {
     mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/admin/en.json']);
-    mockReadFile.mockImplementation(((path: string, opts?: any) => {
-      if (opts?.parse) return { key: 'value' };
-      return '{"key":"value"}';
-    }) as any);
+    mockGetCurrentTranslation.mockReturnValue({ key: 'value' });
     mockNormalizedGlob.mockReturnValue(['/tmp/i18n/admin/en.json']);
 
     compareKeysToFiles({
@@ -156,7 +150,6 @@ describe('compareKeysToFiles', () => {
       translationsPath: '/tmp/i18n',
       addMissingKeys: false,
       fileFormat: 'json',
-      unflat: false,
     });
 
     // Scoped diffs must be keyed as `<scope>/<lang>` (not the global `<lang>`
@@ -175,11 +168,9 @@ describe('compareKeysToFiles', () => {
   });
 
   it('should unflatten translation before writing when unflat is true', () => {
+    unflat = true;
     mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/en.json']);
-    mockReadFile.mockImplementation(((path: string, opts?: any) => {
-      if (opts?.parse) return {};
-      return '{}';
-    }) as any);
+    mockGetCurrentTranslation.mockReturnValue({});
     mockNormalizedGlob.mockReturnValue(['/tmp/i18n/en.json']);
 
     compareKeysToFiles({
@@ -187,12 +178,64 @@ describe('compareKeysToFiles', () => {
       translationsPath: '/tmp/i18n',
       addMissingKeys: true,
       fileFormat: 'json',
-      unflat: true,
     });
 
-    expect(mockWriteFile).toHaveBeenCalledWith(
-      '/tmp/i18n/en.json',
-      expect.objectContaining({ a: { b: 'value' } }),
-    );
+    const [, content] = mockWriteFile.mock.calls[0];
+    expect(JSON.parse(content as string)).toEqual({ a: { b: 'value' } });
+  });
+
+  /**
+   * The translation files used to be read with `JSON.parse` and written back as
+   * JSON, so `find --file-format pot` crashed on the first `.pot` file.
+   */
+  describe('when the file format is pot', () => {
+    it('should parse the translation files as pot', () => {
+      mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/en.pot']);
+      mockGetCurrentTranslation.mockReturnValue({ 'existing.key': 'Existing' });
+      mockNormalizedGlob.mockReturnValue(['/tmp/i18n/en.pot']);
+
+      compareKeysToFiles({
+        scopeToKeys: {
+          __global: { 'existing.key': 'Existing', 'missing.key': '' },
+        },
+        translationsPath: '/tmp/i18n',
+        addMissingKeys: false,
+        fileFormat: 'pot',
+      });
+
+      expect(mockGetCurrentTranslation).toHaveBeenCalledWith({
+        path: '/tmp/i18n/en.pot',
+        fileFormat: 'pot',
+      });
+      expect(mockBuildTable).toHaveBeenCalledWith(
+        expect.objectContaining({
+          diffsPerLang: expect.objectContaining({
+            en: expect.objectContaining({
+              missing: [expect.objectContaining({ path: ['missing.key'] })],
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('should write the missing keys back as pot', () => {
+      mockGetTranslationFilesPath.mockReturnValue(['/tmp/i18n/en.pot']);
+      mockGetCurrentTranslation.mockReturnValue({ 'existing.key': 'Existing' });
+      mockNormalizedGlob.mockReturnValue(['/tmp/i18n/en.pot']);
+
+      compareKeysToFiles({
+        scopeToKeys: {
+          __global: { 'existing.key': 'Existing', 'missing.key': '' },
+        },
+        translationsPath: '/tmp/i18n',
+        addMissingKeys: true,
+        fileFormat: 'pot',
+      });
+
+      const [path, content] = mockWriteFile.mock.calls[0];
+      expect(path).toBe('/tmp/i18n/en.pot');
+      expect(content).toEqual(expect.stringContaining('msgid "missing.key"'));
+      expect(content).toEqual(expect.stringContaining('msgid "existing.key"'));
+    });
   });
 });

--- a/libs/transloco-keys-manager/src/lib/tests/generate-keys.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/generate-keys.spec.ts
@@ -1,0 +1,279 @@
+import path from 'node:path';
+
+import fs from 'fs-extra';
+import { po } from 'gettext-parser';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { setConfig } from '../config';
+import { Config } from '../types';
+import { generateKeys } from '../webpack-plugin/generate-keys';
+
+const root = path.join(__dirname, '__generate-keys__');
+const translationPath = `${root}/i18n`;
+const scopePath = `${root}/custom/admin-i18n`;
+
+function writePot(filePath: string, entries: Record<string, string>) {
+  const body = Object.entries(entries)
+    .map(([msgid, msgstr]) => `msgid "${msgid}"\nmsgstr "${msgstr}"\n`)
+    .join('\n');
+
+  fs.outputFileSync(filePath, `msgid ""\nmsgstr ""\n\n${body}`);
+}
+
+function readPot(filePath: string) {
+  const parsed = po.parse(fs.readFileSync(filePath, 'utf-8'));
+
+  return Object.entries(parsed.translations[''] ?? {})
+    .filter(([msgid]) => msgid.length > 0)
+    .reduce<Record<string, string>>(
+      (acc, [msgid, entry]) => ({ ...acc, [msgid]: entry.msgstr.join('') }),
+      {},
+    );
+}
+
+function buildConfig(overrides: Partial<Config> = {}) {
+  return {
+    langs: ['en'],
+    fileFormat: 'json',
+    unflat: false,
+    ...overrides,
+  } as unknown as Parameters<typeof generateKeys>[0]['config'];
+}
+
+describe('generateKeys', () => {
+  beforeEach(() => {
+    setConfig({ sort: false } as Config);
+    fs.removeSync(root);
+  });
+
+  afterEach(() => fs.removeSync(root));
+
+  it('given a scoped key, when no scope path is mapped, then it should write to the default scope folder', () => {
+    fs.outputJsonSync(`${translationPath}/en.json`, { globalOld: 'g' });
+    fs.outputJsonSync(`${translationPath}/admin/en.json`, { adminOld: 'a' });
+
+    generateKeys({
+      translationPath,
+      scopeToKeys: {
+        __global: { globalNew: '' },
+        admin: { adminNew: '' },
+      },
+      config: buildConfig(),
+    });
+
+    expect(fs.readJsonSync(`${translationPath}/admin/en.json`)).toEqual({
+      adminNew: '',
+      adminOld: 'a',
+    });
+  });
+
+  it('given a global key, when writing, then it should not leak into scope folders', () => {
+    fs.outputJsonSync(`${translationPath}/en.json`, { globalOld: 'g' });
+    fs.outputJsonSync(`${translationPath}/admin/en.json`, { adminOld: 'a' });
+
+    generateKeys({
+      translationPath,
+      scopeToKeys: { __global: { globalNew: '' } },
+      config: buildConfig(),
+    });
+
+    expect(fs.readJsonSync(`${translationPath}/en.json`)).toEqual({
+      globalNew: '',
+      globalOld: 'g',
+    });
+    expect(fs.readJsonSync(`${translationPath}/admin/en.json`)).toEqual({
+      adminOld: 'a',
+    });
+  });
+
+  it('given a mapped scope path, when a stale file exists at the default path, then it should only write to the mapped path', () => {
+    fs.outputJsonSync(`${translationPath}/admin/en.json`, { adminOld: 'a' });
+    fs.outputJsonSync(`${scopePath}/en.json`, { adminOld: 'a' });
+
+    generateKeys({
+      translationPath,
+      scopeToKeys: { __global: {}, admin: { adminNew: '' } },
+      config: buildConfig({ scopePathMap: { admin: scopePath } }),
+    });
+
+    expect(fs.readJsonSync(`${scopePath}/en.json`)).toEqual({
+      adminNew: '',
+      adminOld: 'a',
+    });
+    expect(fs.readJsonSync(`${translationPath}/admin/en.json`)).toEqual({
+      adminOld: 'a',
+    });
+  });
+
+  it('given a file that is not a configured language, when writing, then it should be ignored', () => {
+    fs.outputJsonSync(`${translationPath}/admin/en.json`, {});
+    fs.outputJsonSync(`${translationPath}/admin/notALang.json`, {});
+
+    generateKeys({
+      translationPath,
+      scopeToKeys: { __global: {}, admin: { adminNew: '' } },
+      config: buildConfig(),
+    });
+
+    expect(fs.readJsonSync(`${translationPath}/admin/en.json`)).toEqual({
+      adminNew: '',
+    });
+    expect(fs.readJsonSync(`${translationPath}/admin/notALang.json`)).toEqual(
+      {},
+    );
+  });
+
+  it('given a pot file format, when writing, then it should not parse the file as json', () => {
+    writePot(`${translationPath}/en.pot`, { globalOld: 'g' });
+
+    generateKeys({
+      translationPath,
+      scopeToKeys: { __global: { globalNew: '' } },
+      config: buildConfig({ fileFormat: 'pot' }),
+    });
+
+    expect(readPot(`${translationPath}/en.pot`)).toEqual({
+      globalOld: 'g',
+      globalNew: '',
+    });
+  });
+
+  describe('pot file format', () => {
+    const potConfig = (overrides: Partial<Config> = {}) =>
+      buildConfig({ fileFormat: 'pot', ...overrides });
+
+    it('given a scoped key, when no scope path is mapped, then it should write to the default scope folder', () => {
+      writePot(`${translationPath}/en.pot`, { globalOld: 'g' });
+      writePot(`${translationPath}/admin/en.pot`, { adminOld: 'a' });
+
+      generateKeys({
+        translationPath,
+        scopeToKeys: {
+          __global: { globalNew: '' },
+          admin: { adminNew: '' },
+        },
+        config: potConfig(),
+      });
+
+      expect(readPot(`${translationPath}/admin/en.pot`)).toEqual({
+        adminOld: 'a',
+        adminNew: '',
+      });
+      expect(readPot(`${translationPath}/en.pot`)).toEqual({
+        globalOld: 'g',
+        globalNew: '',
+      });
+    });
+
+    it('given a mapped scope path, when a stale file exists at the default path, then it should only write to the mapped path', () => {
+      writePot(`${translationPath}/admin/en.pot`, { adminOld: 'a' });
+      writePot(`${scopePath}/en.pot`, { adminOld: 'a' });
+
+      generateKeys({
+        translationPath,
+        scopeToKeys: { __global: {}, admin: { adminNew: '' } },
+        config: potConfig({ scopePathMap: { admin: scopePath } }),
+      });
+
+      expect(readPot(`${scopePath}/en.pot`)).toEqual({
+        adminOld: 'a',
+        adminNew: '',
+      });
+      expect(readPot(`${translationPath}/admin/en.pot`)).toEqual({
+        adminOld: 'a',
+      });
+    });
+
+    it('given multiple configured languages, when writing, then it should update every language file', () => {
+      writePot(`${translationPath}/en.pot`, { globalOld: 'g' });
+      writePot(`${translationPath}/es.pot`, { globalOld: 'gs' });
+
+      generateKeys({
+        translationPath,
+        scopeToKeys: { __global: { globalNew: '' } },
+        config: potConfig({ langs: ['en', 'es'] }),
+      });
+
+      expect(readPot(`${translationPath}/en.pot`)).toEqual({
+        globalOld: 'g',
+        globalNew: '',
+      });
+      expect(readPot(`${translationPath}/es.pot`)).toEqual({
+        globalOld: 'gs',
+        globalNew: '',
+      });
+    });
+
+    it('given a file that is not a configured language, when writing, then it should be ignored', () => {
+      writePot(`${translationPath}/en.pot`, {});
+      writePot(`${translationPath}/notALang.pot`, {});
+
+      generateKeys({
+        translationPath,
+        scopeToKeys: { __global: { globalNew: '' } },
+        config: potConfig(),
+      });
+
+      expect(readPot(`${translationPath}/en.pot`)).toEqual({ globalNew: '' });
+      expect(readPot(`${translationPath}/notALang.pot`)).toEqual({});
+    });
+
+    it('given an empty pot file, when writing, then it should add the extracted keys', () => {
+      fs.outputFileSync(`${translationPath}/en.pot`, '');
+
+      generateKeys({
+        translationPath,
+        scopeToKeys: { __global: { globalNew: '' } },
+        config: potConfig(),
+      });
+
+      expect(readPot(`${translationPath}/en.pot`)).toEqual({ globalNew: '' });
+    });
+
+    it('given an existing translated key, when the same key is extracted, then it should keep the existing value', () => {
+      writePot(`${translationPath}/en.pot`, { greeting: 'Hello' });
+
+      generateKeys({
+        translationPath,
+        scopeToKeys: { __global: { greeting: '', farewell: '' } },
+        config: potConfig(),
+      });
+
+      expect(readPot(`${translationPath}/en.pot`)).toEqual({
+        greeting: 'Hello',
+        farewell: '',
+      });
+    });
+
+    it('given unflat is enabled, when writing, then it should keep the msgids flat and preserve existing values', () => {
+      setConfig({ sort: false, unflat: true } as Config);
+      writePot(`${translationPath}/en.pot`, { 'a.b': 'x' });
+
+      generateKeys({
+        translationPath,
+        scopeToKeys: { __global: { 'a.b': '', 'a.c': '' } },
+        config: potConfig({ unflat: true }),
+      });
+
+      expect(readPot(`${translationPath}/en.pot`)).toEqual({
+        'a.b': 'x',
+        'a.c': '',
+      });
+    });
+  });
+
+  it('given unflat is enabled, when writing json, then it should nest the extracted keys', () => {
+    setConfig({ sort: false, unflat: true } as Config);
+    fs.outputJsonSync(`${translationPath}/en.json`, {});
+
+    generateKeys({
+      translationPath,
+      scopeToKeys: { __global: { 'a.b': '' } },
+      config: buildConfig({ unflat: true }),
+    });
+
+    expect(fs.readJsonSync(`${translationPath}/en.json`)).toEqual({
+      a: { b: '' },
+    });
+  });
+});

--- a/libs/transloco-keys-manager/src/lib/tests/keys-detective-index.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/keys-detective-index.spec.ts
@@ -75,7 +75,6 @@ describe('findMissingKeys', () => {
       translationsPath: '/tmp/i18n',
       addMissingKeys: false,
       fileFormat: 'json',
-      unflat: false,
     });
   });
 });

--- a/libs/transloco-keys-manager/src/lib/tests/keys-detective-index.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/keys-detective-index.spec.ts
@@ -74,7 +74,6 @@ describe('findMissingKeys', () => {
       scopeToKeys,
       translationsPath: '/tmp/i18n',
       addMissingKeys: false,
-      emitErrorOnExtraKeys: false,
       fileFormat: 'json',
       unflat: false,
     });

--- a/libs/transloco-keys-manager/src/lib/tests/marker.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/marker.spec.ts
@@ -3,33 +3,51 @@ import { describe, expect, it } from 'vitest';
 import { marker } from '../marker';
 
 describe('marker', () => {
-  describe('when called with a key', () => {
-    it('should return the key as is', () => {
-      expect(marker('some.key')).toBe('some.key');
-    });
+  it('given a key, when marked, then it should be returned as is', () => {
+    const key = 'some.key';
 
-    it('should return an array of keys as is', () => {
-      expect(marker(['a.key', 'b.key'])).toEqual(['a.key', 'b.key']);
-    });
+    const result = marker(key);
+
+    expect(result).toBe('some.key');
+  });
+
+  it('given an array of keys, when marked, then it should be returned as is', () => {
+    const keys = ['a.key', 'b.key'];
+
+    const result = marker(keys);
+
+    expect(result).toEqual(['a.key', 'b.key']);
   });
 
   /**
    * `params` is ignored, it only exists so a `translate()` call can be
    * swapped for a `marker()` one without changing the call site.
    */
-  describe('when called with the compatibility params', () => {
-    it('should ignore them and return the key', () => {
-      expect(marker('some.key', { name: 'Transloco' })).toBe('some.key');
-    });
+  it('given compatibility params, when marked, then they should be ignored', () => {
+    const key = 'some.key';
+    const params = { name: 'Transloco' };
 
-    it('should ignore them when a scope is passed as well', () => {
-      expect(marker('some.key', { name: 'Transloco' }, 'admin')).toBe(
-        'some.key',
-      );
-    });
+    const result = marker(key, params);
 
-    it('should still accept an undefined placeholder before the scope', () => {
-      expect(marker('some.key', undefined, 'admin')).toBe('some.key');
-    });
+    expect(result).toBe('some.key');
+  });
+
+  it('given compatibility params and a scope, when marked, then both should be ignored', () => {
+    const key = 'some.key';
+    const params = { name: 'Transloco' };
+    const scope = 'admin';
+
+    const result = marker(key, params, scope);
+
+    expect(result).toBe('some.key');
+  });
+
+  it('given an undefined params placeholder and a scope, when marked, then the key should be returned', () => {
+    const key = 'some.key';
+    const scope = 'admin';
+
+    const result = marker(key, undefined, scope);
+
+    expect(result).toBe('some.key');
   });
 });

--- a/libs/transloco-keys-manager/src/lib/tests/marker.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/marker.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { marker } from '../marker';
+
+describe('marker', () => {
+  describe('when called with a key', () => {
+    it('should return the key as is', () => {
+      expect(marker('some.key')).toBe('some.key');
+    });
+
+    it('should return an array of keys as is', () => {
+      expect(marker(['a.key', 'b.key'])).toEqual(['a.key', 'b.key']);
+    });
+  });
+
+  /**
+   * `params` is ignored, it only exists so a `translate()` call can be
+   * swapped for a `marker()` one without changing the call site.
+   */
+  describe('when called with the compatibility params', () => {
+    it('should ignore them and return the key', () => {
+      expect(marker('some.key', { name: 'Transloco' })).toBe('some.key');
+    });
+
+    it('should ignore them when a scope is passed as well', () => {
+      expect(marker('some.key', { name: 'Transloco' }, 'admin')).toBe(
+        'some.key',
+      );
+    });
+
+    it('should still accept an undefined placeholder before the scope', () => {
+      expect(marker('some.key', undefined, 'admin')).toBe('some.key');
+    });
+  });
+});

--- a/libs/transloco-keys-manager/src/lib/tests/performance.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/performance.spec.ts
@@ -194,6 +194,7 @@ describe('Performance Benchmarks', () => {
         file: path.join(PERF_TMP, `comp${i}.html`),
         content,
         scopes,
+        langs: ['en'],
         defaultValue: '',
         scopeToKeys,
       });
@@ -214,6 +215,7 @@ describe('Performance Benchmarks', () => {
       file: path.join(PERF_TMP, 'comp0.html'),
       content: generateTemplate(0, KEYS_PER_COMPONENT),
       scopes,
+      langs: ['en'],
       defaultValue: '',
       scopeToKeys: sampleScopeToKeys,
     });
@@ -242,6 +244,7 @@ describe('Performance Benchmarks', () => {
         file: path.join(PERF_TMP, `skip${i}.html`),
         content,
         scopes,
+        langs: ['en'],
         defaultValue: '',
         scopeToKeys: skipScopeToKeys,
       });
@@ -257,6 +260,7 @@ describe('Performance Benchmarks', () => {
         file: path.join(PERF_TMP, 'transloco-benchmark.html'),
         content: translocoContent,
         scopes,
+        langs: ['en'],
         defaultValue: '',
         scopeToKeys,
       });
@@ -339,6 +343,7 @@ describe('Performance Benchmarks', () => {
         file: path.join(PERF_TMP, 'parse-once.html'),
         content: largeTemplate,
         scopes,
+        langs: ['en'],
         defaultValue: '',
         scopeToKeys: { __global: {} },
       };
@@ -356,6 +361,7 @@ describe('Performance Benchmarks', () => {
         file: path.join(PERF_TMP, 'parse-once.html'),
         content: largeTemplate,
         scopes,
+        langs: ['en'],
         defaultValue: '',
         scopeToKeys: { __global: {} },
       });

--- a/libs/transloco-keys-manager/src/lib/tests/resolvers.utils.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/resolvers.utils.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveScopeAlias } from '../keys-builder/utils/resolvers.utils';
+import { Scopes } from '../types';
+
+const scopes: Scopes = {
+  scopeToAlias: {
+    'some/nested': 'someNested',
+    some: 'some',
+  },
+  aliasToScope: {
+    someNested: 'some/nested',
+    some: 'some',
+  },
+};
+
+const langs = ['en', 'es'];
+
+describe('resolveScopeAlias', () => {
+  describe('when the scope path is registered', () => {
+    it('should return its alias', () => {
+      expect(
+        resolveScopeAlias({ scopePath: 'some/nested', scopes, langs }),
+      ).toBe('someNested');
+    });
+  });
+
+  describe('when the scope path ends with a configured language', () => {
+    it('should strip the language and return the alias', () => {
+      expect(
+        resolveScopeAlias({ scopePath: 'some/nested/en', scopes, langs }),
+      ).toBe('someNested');
+    });
+  });
+
+  /**
+   * Popping the last segment unconditionally used to resolve an unrelated
+   * path to its parent scope, attributing the keys to the wrong scope.
+   */
+  describe('when the last segment is not a configured language', () => {
+    it('should not strip it and should return no alias', () => {
+      expect(
+        resolveScopeAlias({ scopePath: 'some/nested/deep', scopes, langs }),
+      ).toBeUndefined();
+    });
+
+    it('should not fall back to a parent scope', () => {
+      expect(
+        resolveScopeAlias({ scopePath: 'some/unregistered', scopes, langs }),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/libs/transloco-keys-manager/src/lib/tests/resolvers.utils.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/resolvers.utils.spec.ts
@@ -17,37 +17,39 @@ const scopes: Scopes = {
 const langs = ['en', 'es'];
 
 describe('resolveScopeAlias', () => {
-  describe('when the scope path is registered', () => {
-    it('should return its alias', () => {
-      expect(
-        resolveScopeAlias({ scopePath: 'some/nested', scopes, langs }),
-      ).toBe('someNested');
-    });
+  it('given a registered scope path, when resolved, then it should return its alias', () => {
+    const scopePath = 'some/nested';
+
+    const result = resolveScopeAlias({ scopePath, scopes, langs });
+
+    expect(result).toBe('someNested');
   });
 
-  describe('when the scope path ends with a configured language', () => {
-    it('should strip the language and return the alias', () => {
-      expect(
-        resolveScopeAlias({ scopePath: 'some/nested/en', scopes, langs }),
-      ).toBe('someNested');
-    });
+  it('given a scope path ending with a configured language, when resolved, then the language should be stripped', () => {
+    const scopePath = 'some/nested/en';
+
+    const result = resolveScopeAlias({ scopePath, scopes, langs });
+
+    expect(result).toBe('someNested');
   });
 
   /**
    * Popping the last segment unconditionally used to resolve an unrelated
    * path to its parent scope, attributing the keys to the wrong scope.
    */
-  describe('when the last segment is not a configured language', () => {
-    it('should not strip it and should return no alias', () => {
-      expect(
-        resolveScopeAlias({ scopePath: 'some/nested/deep', scopes, langs }),
-      ).toBeUndefined();
-    });
+  it('given a trailing segment that is not a configured language, when resolved, then it should return no alias', () => {
+    const scopePath = 'some/nested/deep';
 
-    it('should not fall back to a parent scope', () => {
-      expect(
-        resolveScopeAlias({ scopePath: 'some/unregistered', scopes, langs }),
-      ).toBeUndefined();
-    });
+    const result = resolveScopeAlias({ scopePath, scopes, langs });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('given an unregistered scope path, when resolved, then it should not fall back to a parent scope', () => {
+    const scopePath = 'some/unregistered';
+
+    const result = resolveScopeAlias({ scopePath, scopes, langs });
+
+    expect(result).toBeUndefined();
   });
 });

--- a/libs/transloco-keys-manager/src/lib/tests/scope.utils.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/scope.utils.spec.ts
@@ -17,27 +17,36 @@ describe('scope.utils', () => {
       scopeToAlias: { 'admin/dashboard': 'dashboard' },
       aliasToScope: { dashboard: 'admin/dashboard' },
     });
+  });
+
+  it('given several scopes, when added, then every pair should be kept', () => {
+    addScope('admin/dashboard', 'dashboard');
+    addScope('admin/reports', 'reports');
+
+    expect(getScopes()).toEqual({
+      scopeToAlias: {
+        'admin/dashboard': 'dashboard',
+        'admin/reports': 'reports',
+      },
+      aliasToScope: {
+        dashboard: 'admin/dashboard',
+        reports: 'admin/reports',
+      },
+    });
+  });
+
+  it('given a registered scope, when checked, then hasScope should reflect it', () => {
+    addScope('admin/dashboard', 'dashboard');
+
     expect(hasScope('admin/dashboard')).toBe(true);
+    expect(hasScope('admin/reports')).toBe(false);
   });
 
-  it('given an existing scope, when it is re-aliased, then the stale alias should be removed', () => {
-    addScope('admin/dashboard', 'oldAlias');
-    addScope('admin/dashboard', 'newAlias');
+  it('given registered scopes, when reset, then both maps should be emptied', () => {
+    addScope('admin/dashboard', 'dashboard');
+    resetScopes();
 
-    expect(getScopes()).toEqual({
-      scopeToAlias: { 'admin/dashboard': 'newAlias' },
-      aliasToScope: { newAlias: 'admin/dashboard' },
-    });
-  });
-
-  it('given an alias already in use, when another scope claims it, then the stale scope should be removed', () => {
-    addScope('admin/dashboard', 'shared');
-    addScope('admin/reports', 'shared');
-
-    expect(getScopes()).toEqual({
-      scopeToAlias: { 'admin/reports': 'shared' },
-      aliasToScope: { shared: 'admin/reports' },
-    });
+    expect(getScopes()).toEqual({ scopeToAlias: {}, aliasToScope: {} });
     expect(hasScope('admin/dashboard')).toBe(false);
   });
 });

--- a/libs/transloco-keys-manager/src/lib/tests/scope.utils.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/scope.utils.spec.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  addScope,
+  getScopes,
+  hasScope,
+  resetScopes,
+} from '../keys-builder/utils/scope.utils';
+
+describe('scope.utils', () => {
+  beforeEach(() => resetScopes());
+
+  it('given a scope and an alias, when added, then both directions should map', () => {
+    addScope('admin/dashboard', 'dashboard');
+
+    expect(getScopes()).toEqual({
+      scopeToAlias: { 'admin/dashboard': 'dashboard' },
+      aliasToScope: { dashboard: 'admin/dashboard' },
+    });
+    expect(hasScope('admin/dashboard')).toBe(true);
+  });
+
+  it('given an existing scope, when it is re-aliased, then the stale alias should be removed', () => {
+    addScope('admin/dashboard', 'oldAlias');
+    addScope('admin/dashboard', 'newAlias');
+
+    expect(getScopes()).toEqual({
+      scopeToAlias: { 'admin/dashboard': 'newAlias' },
+      aliasToScope: { newAlias: 'admin/dashboard' },
+    });
+  });
+
+  it('given an alias already in use, when another scope claims it, then the stale scope should be removed', () => {
+    addScope('admin/dashboard', 'shared');
+    addScope('admin/reports', 'shared');
+
+    expect(getScopes()).toEqual({
+      scopeToAlias: { 'admin/reports': 'shared' },
+      aliasToScope: { shared: 'admin/reports' },
+    });
+    expect(hasScope('admin/dashboard')).toBe(false);
+  });
+});

--- a/libs/transloco-keys-manager/src/lib/types.ts
+++ b/libs/transloco-keys-manager/src/lib/types.ts
@@ -35,6 +35,7 @@ export type ExtractionResult = {
 export type ExtractorConfig = {
   file: string;
   scopes: Scopes;
+  langs: string[];
   defaultValue?: string;
   scopeToKeys: ScopeMap;
 };

--- a/libs/transloco-keys-manager/src/lib/types.ts
+++ b/libs/transloco-keys-manager/src/lib/types.ts
@@ -32,6 +32,13 @@ export type ExtractionResult = {
   fileCount: number;
 };
 
+export type KeysDetectiveResult = {
+  /** Missing keys were found in at least one translation file. */
+  hasMissingKeys: boolean;
+  /** Extra keys were found in at least one translation file. */
+  hasExtraKeys: boolean;
+};
+
 export type ExtractorConfig = {
   file: string;
   scopes: Scopes;

--- a/libs/transloco-keys-manager/src/lib/utils/file.utils.ts
+++ b/libs/transloco-keys-manager/src/lib/utils/file.utils.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync } from 'fs';
 
 import { stringify } from './object.utils';
+import { isString } from './validators.utils';
 
 export function readFile(file: string): string;
 export function readFile(file: string, config: { parse: false }): string;
@@ -22,6 +23,8 @@ export function readFile(
   return content;
 }
 
-export function writeFile(fileName: string, content: object) {
-  writeFileSync(fileName, stringify(content), { encoding: 'utf-8' });
+export function writeFile(fileName: string, content: object | string) {
+  const output = isString(content) ? content : stringify(content);
+
+  writeFileSync(fileName, output, { encoding: 'utf-8' });
 }

--- a/libs/transloco-keys-manager/src/lib/webpack-plugin/generate-keys.ts
+++ b/libs/transloco-keys-manager/src/lib/webpack-plugin/generate-keys.ts
@@ -1,12 +1,12 @@
 import { basename } from 'node:path';
 
 import { TranslocoGlobalConfig } from '@jsverse/transloco-utils';
-import { unflatten } from 'flat';
 import { sync as globSync } from 'glob';
 
+import { createTranslation } from '../keys-builder/utils/create-translation';
+import { getCurrentTranslation } from '../keys-builder/utils/get-current-translation';
 import { ScopeMap, Config } from '../types';
-import { readFile, writeFile } from '../utils/file.utils';
-import { mergeDeep } from '../utils/object.utils';
+import { writeFile } from '../utils/file.utils';
 
 type Params = {
   translationPath: string;
@@ -29,10 +29,13 @@ export function generateKeys({ translationPath, scopeToKeys, config }: Params) {
   const scopePaths = config.scopePathMap || {};
 
   const result = [];
+  // Scopes with an explicit path must not fall back to the default location.
+  const resolvedScopes = new Set<string>();
 
   for (const [scope, path] of Object.entries(scopePaths)) {
     const keys = scopeToKeys[scope];
     if (keys) {
+      resolvedScopes.add(scope);
       result.push({
         keys,
         files: globSync(`${path}/*.${config.fileFormat}`).filter(
@@ -43,23 +46,37 @@ export function generateKeys({ translationPath, scopeToKeys, config }: Params) {
   }
 
   for (const [scope, keys] of Object.entries(scopeToKeys)) {
-    if (keys) {
+    if (keys && !resolvedScopes.has(scope)) {
       const isGlobal = scope === '__global';
 
       result.push({
         keys,
         files: globSync(
-          `${translationPath}/${isGlobal ? '' : scope}*.${config.fileFormat}`,
+          `${translationPath}/${isGlobal ? '' : `${scope}/`}*.${
+            config.fileFormat
+          }`,
         ).filter(filterLangs(config)),
       });
     }
   }
 
-  for (const { files, keys: extractedKeys } of result) {
-    const keys = config.unflat ? unflatten(extractedKeys) : extractedKeys;
+  for (const { files, keys } of result) {
     for (const filePath of files) {
-      const translation = readFile(filePath, { parse: true });
-      writeFile(filePath, mergeDeep({}, keys, translation));
+      const currentTranslation = getCurrentTranslation({
+        path: filePath,
+        fileFormat: config.fileFormat,
+      });
+
+      writeFile(
+        filePath,
+        createTranslation({
+          translation: keys,
+          currentTranslation,
+          replace: false,
+          removeExtraKeys: false,
+          fileFormat: config.fileFormat,
+        }),
+      );
     }
   }
 }


### PR DESCRIPTION
Follow-up to #943 / #981. Each item below was verified against current code
before changing anything; findings that turned out to be invalid are listed at
the bottom with evidence rather than silently applied.

## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — no public API change

## PR Type

- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)

## What is the current behavior?

Issue Number: N/A (follow-up to review feedback on #943)

- `find --file-format pot` crashes: `compareKeysToFiles` always called
  `readFile(filePath, { parse: true })`, i.e. `JSON.parse` on a POT file, and
  the `addMissingKeys` write path was JSON-only. POT is broken end to end.
- The webpack plugin never writes scoped keys. `generateKeys` globbed
  `${translationPath}/${scope}*.${fileFormat}`, missing the `/` before `*`, so
  `i18n/admin*.json` can never match the canonical `i18n/admin/en.json` layout
  produced by `buildScopeFilePaths`.
- `buildTable` called `process.exit(1)` / `(2)` from inside a rendering helper,
  truncating its own summary table and killing any programmatic caller. Exit
  code 2 was unreachable whenever missing keys were present.
- The CLI never awaited `buildTranslationFiles()`, so extraction failures
  surfaced as unhandled rejections instead of a deterministic non-zero exit.
- `resolveScopeAlias` popped the trailing path segment unconditionally, so
  `admin/reports` resolved to the parent `admin` scope.
- `marker(key, params?: undefined, scope?)` rejected real params at compile
  time while its JSDoc promised the parameter existed "for compatibility".
- An invalid or missing CLI command logged a prompt and exited 0.

## What is the new behavior?

**POT support in `find`** — `compareKeysToFiles` parses via
`getCurrentTranslation({ path, fileFormat })` and writes via
`createTranslation({ ..., fileFormat, replace: true })`. `writeFile` accepts
`string | object`. The redundant `unflat` option was dropped: both helpers
already read it from the resolved config, so passing it separately was a second
source of truth.

**Webpack plugin scope handling** — added the missing `/` and a `resolvedScopes`
set so scopes resolved through `scopePathMap` are skipped in the default-glob
loop. Both halves are required: the separator fix alone makes the duplicate
merge reachable for the first time. `generateKeys` also now routes through
`getCurrentTranslation` / `createTranslation`, fixing the same JSON-only parse
bug there. This file had **zero** test coverage, which is why the bugs survived;
it now has 13 tests, 7 of them POT-specific.

**Exit codes** — `buildTable` returns a `KeysDetectiveResult` of pure diff facts;
all exit-code policy moved to the CLI, which reads the **resolved** config via
`getConfig()` (the flags can come from `transloco.config.js`, not just argv).
`process.exitCode` replaces `process.exit()` so output is no longer truncated.
Missing (1) still takes precedence over extra (2).

**Async CLI** — dispatch runs from an `async run()` with
`.catch(err => { console.error(err); process.exitCode = 1; })`. Invalid/missing
commands now exit 1. `--input` entries are trimmed, empties dropped, and a
config with no valid path left is rejected.

**Scope alias** — `resolveScopeAlias` receives the configured `langs` and only
strips a trailing segment when it is one of them.

**`marker` params** — widened to a local `MarkerParams = Record<string, any>`
alias, mirroring transloco's `HashMap` without adding a dependency on
`@jsverse/transloco`.

**Types/cleanups** — `build-table` uses `DiffNew<any>[]` / `DiffDeleted<any>[]`
instead of `any[]`; removed a redundant `as object` assertion; added POT
coverage to the remove-extra-keys nested-translation guard.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Published surface is unchanged: only `TranslocoExtractKeysWebpackPlugin` and
`marker` are exported. `buildTable` / `compareKeysToFiles` / `findMissingKeys`
signatures are internal. The `marker` params widening is purely additive —
previously-valid calls still compile.

Behavioral note for CI: an invalid or missing command now exits 1 instead of 0.

## Other information

**Reviewed but intentionally not applied** (verified as invalid, with evidence):

1. *"`createPot` should unflatten before `resolveTranslation`"* — the premise is
   right (`parsePot` does unflatten under `unflat`), but the conclusion is not.
   `resolveTranslation` merges `mergeDeep({}, translation, currentTranslation)`,
   so existing content is applied last and the trailing `flatten()` lets real
   values overwrite the empty extracted placeholders. Measured:

   | case | current | proposed |
   |---|---|---|
   | `{a:{b:'x'}}` + `{'a.b':'','a.c':''}` | `a.b→"x"`, `a.c→""` | same |
   | `{a:{b:'x'}}` + `{'a.b.c':'','a.d':''}` | `a.b.c`, `a.d`, `a.b→"x"` | **`a.b.c` dropped** |

   Unflattening first collapses `a.b.c` into the `a.b` string node. Now locked in
   by a POT+unflat test in `generate-keys.spec.ts`.

2. *"`run-prettier.spec` should throw from the module import"* — implemented and
   reverted: Vitest replaces factory throws *and* rejections with its own error,
   dropping `err.code`, so `runPrettier` warns and the test asserts nothing.

3. *"`addScope` should remove stale reverse mappings"* — reverted after review
   discussion, see the reviewer answers below.

**Already resolved on master, no action needed:** `build-translation-file`
new/modified via `fs.existsSync`, `structural-directive` `$implicit` guard,
`inline-template` iterating all matches, `sanitizeForRegex` metacharacters,
per-instance webpack `init`, anchored marker import selector,
`ERR_MODULE_NOT_FOUND`, `normalizedGlob` ignore merging, fixture lint
exclusions, `service.extractor` join, perf spec assertions and temp dir,
`resolveConfig` mock path, `spec-utils` `vi.doMock`, `typescript` peer dep.

**Not applicable:** HTMLHint is not used anywhere in this repo.

**Deferred:** typing the webpack plugin's `apply`/`tapPromise` needs `webpack`
as a devDependency (not currently present).

---

# Answers to review comments to PR #981 @shaharkazaz 

## 1. `addScope` — "we are always overriding the values, even if a present scope is passed"

**You're right, and I've reverted it.** Your objection made me check the caller,
which I should have done first:

```ts
// update-scopes-map.ts:114
if (scope && !hasScope(scope)) {
  addScope(scope, alias);
}
```

`addScope` is only ever reached for a scope that isn't registered yet, so the
"same scope, new alias" case the change guarded against **cannot happen**. That
half was dead code.

The one reachable case is two *different* scopes colliding on the same alias,
since `hasScope` checks the scope key only. It's real — `toCamelCase` strips
`/`, `-` and spaces:

```
"admin/reports" -> "adminReports"
"admin-reports" -> "adminReports"
"admin reports" -> "adminReports"
```

But my change didn't fix that, it just swapped one wrong outcome for another.
Today the first scope keeps its forward mapping and its keys get written into
the *second* scope's folder. With my change it loses the mapping entirely and
its keys fall into the global file. Neither is correct — an alias collision is a
configuration error that should **warn**, not silently pick a winner.

So the change is reverted. I kept a `scope.utils.spec.ts` covering
`addScope`/`hasScope`/`getScopes`/`resetScopes`, since the file had no tests at
all, but it asserts only the uncontroversial behavior — nothing about
collisions. Happy to open a separate issue for a collision warning if you think
it's worth it.

## 2. "How is `emitErrorOnExtraKeys` related to the result of `hasExtraKeys`?"

It isn't, and that was the bug. `buildTable` now returns **facts only**:

```ts
export type KeysDetectiveResult = {
  hasMissingKeys: boolean;
  hasExtraKeys: boolean;
};
```

`hasExtraKeys` means "the diff found extra keys" — nothing more.
`emitErrorOnExtraKeys` is a *policy* about whether that fact should fail the
build, and it no longer reaches `buildTable` at all; I removed the parameter and
its plumbing through `compareKeysToFiles`. `addMissingKeys` survives in
`buildTable` for one reason only: the "Added all missing keys" success log.

## 3. "Don't mix these internally... decouple the error emission"

Done — all policy now lives in the CLI, which is the only layer that should own
exit codes:

```ts
const { hasMissingKeys, hasExtraKeys } = findMissingKeys(resolvedConfig);
// Read the resolved config, the flags may come from `transloco.config.js`.
const { addMissingKeys, emitErrorOnExtraKeys } = getConfig();

if (hasMissingKeys && !addMissingKeys) {
  process.exitCode = 1;
} else if (hasExtraKeys && emitErrorOnExtraKeys) {
  process.exitCode = 2;
}
```

Two details worth flagging. The CLI reads `getConfig()` rather than its own
parsed args, because both flags can come from `transloco.config.js` — using argv
gave a wrong exit 1 where a config-file `addMissingKeys: true` should have
produced 2; I verified that case end to end. And `process.exitCode` replaces
`process.exit()`, which previously truncated the summary table mid-render and
made exit 2 unreachable whenever missing keys were also present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer CLI validation for translation paths and reliable failure status codes.
  - Added language-aware scope resolution and configured-language handling.
  - Added POT-format support for comparing and generating translation files.
  - Translation generation now preserves existing translations and avoids duplicate scope processing.
  - Added support for writing serialized data or plain-text files.

- **Bug Fixes**
  - Fixed incorrect parent-scope resolution for non-language path segments.
  - Improved missing- and extra-key detection and reporting.
  - Corrected removal of unused dotted keys in unflattened translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->