### PR TITLE
ci(release): announce releases in discord

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,6 +338,21 @@ jobs:
           if [[ "$DRY_RUN" == "true" ]]; then DRY=(--dry-run); fi
           npx nx release publish --access public --tag "$TAG" --verbose "${DRY[@]}"
 
+      # Cosmetic and deliberately last: the tag is pushed and the tarballs are
+      # on npm by now, so a Discord outage must not fail the job and tempt a
+      # re-run. The script self-skips while the secret is unset.
+      #
+      # Setup: create a webhook on the #releases channel (Edit Channel ->
+      # Integrations -> Webhooks) and store its URL as DISCORD_RELEASES_WEBHOOK.
+      - name: Announce release on Discord
+        if: ${{ !inputs.dry-run }}
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_RELEASES_WEBHOOK }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.value }}
+        run: node .github/workflows/scripts/announce-release.mts
+
       - name: Summary
         if: always()
         env:

--- a/.github/workflows/scripts/announce-release.mts
+++ b/.github/workflows/scripts/announce-release.mts
@@ -1,0 +1,81 @@
+/**
+ * Announces a release in the Discord #releases channel.
+ *
+ * Run by `.github/workflows/release.yml` as `node .github/workflows/scripts/announce-release.mts`,
+ * matching how the other `*.mts` scripts are invoked — Node strips the types, so there is
+ * nothing to install and no loader to configure.
+ *
+ * Best-effort: by the time this runs the release is already published and tagged, so no
+ * failure here may take the release down with it. The workflow step is continue-on-error.
+ */
+import { buildAnnouncement } from './release-embed.mts';
+
+const API = process.env.GITHUB_API_URL ?? 'https://api.github.com';
+const webhook = process.env.DISCORD_WEBHOOK;
+const version = process.env.VERSION;
+const repo = process.env.GITHUB_REPOSITORY;
+const token = process.env.GITHUB_TOKEN;
+
+/** The notes are a bonus; on any failure the embed still carries the links. */
+async function releaseNotes(): Promise<string> {
+  try {
+    const response = await fetch(
+      `${API}/repos/${repo}/releases/tags/releases/${version}`,
+      {
+        headers: {
+          accept: 'application/vnd.github+json',
+          authorization: `Bearer ${token}`,
+          'x-github-api-version': '2022-11-28',
+        },
+      },
+    );
+    if (!response.ok) {
+      console.log(
+        `::warning::Could not read the release notes (${response.status}).`,
+      );
+      return '';
+    }
+    const release = (await response.json()) as { body?: string | null };
+    return release.body ?? '';
+  } catch {
+    console.log('::warning::Could not read the release notes.');
+    return '';
+  }
+}
+
+async function main(): Promise<void> {
+  if (!webhook) {
+    console.log(
+      '::notice::DISCORD_RELEASES_WEBHOOK is not set; skipping the announcement.',
+    );
+    return;
+  }
+  if (!version || !repo) {
+    throw new Error('VERSION and GITHUB_REPOSITORY must both be set');
+  }
+
+  const payload = buildAnnouncement({
+    version,
+    repo,
+    notes: await releaseNotes(),
+  });
+
+  const response = await fetch(webhook, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Discord returned ${response.status}: ${await response.text()}`,
+    );
+  }
+  console.log(`Announced v${version} in Discord.`);
+}
+
+main().catch((error) => {
+  console.log(
+    `::warning::Discord announcement failed: ${error instanceof Error ? error.message : String(error)}. The release itself succeeded.`,
+  );
+  process.exitCode = 1;
+});

--- a/.github/workflows/scripts/release-embed.mts
+++ b/.github/workflows/scripts/release-embed.mts
@@ -1,0 +1,61 @@
+/**
+ * Builds the Discord webhook payload announcing a release.
+ *
+ * Kept pure so it can be tested without a webhook — `announce-release.mts` does the I/O.
+ */
+
+/** Discord caps an embed description at 4096 characters; the rest is the wrapper. */
+const MAX_NOTES = 1400;
+
+const STABLE = 0x2ecc71;
+const PRERELEASE = 0xe67e22;
+
+export interface Release {
+  version: string;
+  /** `owner/repo` */
+  repo: string;
+  /** Release notes; empty is fine, the links carry the message on their own. */
+  notes: string;
+}
+
+/** Spread, not `slice`: indexing by code point never splits an emoji in half. */
+function truncate(notes: string): string {
+  const codePoints = [...notes];
+  return codePoints.length > MAX_NOTES
+    ? `${codePoints.slice(0, MAX_NOTES).join('')}…`
+    : notes;
+}
+
+export function buildAnnouncement({ version, repo, notes }: Release) {
+  const isPrerelease = version.includes('-');
+  const distTag = isPrerelease ? 'next' : 'latest';
+
+  // The tag pattern is `releases/{version}`, so the permalink doubles that segment.
+  const releaseUrl = `https://github.com/${repo}/releases/tag/releases/${version}`;
+  const changelogUrl = `https://github.com/${repo}/blob/master/CHANGELOG.md`;
+  const npmUrl = `https://www.npmjs.com/package/@jsverse/transloco/v/${version}`;
+
+  return {
+    username: 'Transloco',
+    embeds: [
+      {
+        title: isPrerelease
+          ? `🧪 @jsverse/transloco v${version} · prerelease`
+          : `🎉 @jsverse/transloco v${version}`,
+        url: releaseUrl,
+        color: isPrerelease ? PRERELEASE : STABLE,
+        description: [
+          '```bash',
+          `npm i @jsverse/transloco@${distTag}`,
+          '```',
+          truncate(notes),
+          '',
+          `[Release notes](${releaseUrl}) · [Changelog](${changelogUrl}) · [npm](${npmUrl})`,
+        ].join('\n'),
+        fields: [
+          { name: 'npm dist-tag', value: `\`${distTag}\``, inline: true },
+        ],
+      },
+    ],
+  };
+}

--- a/.github/workflows/scripts/release-embed.test.mts
+++ b/.github/workflows/scripts/release-embed.test.mts
@@ -1,0 +1,91 @@
+/**
+ * Run with: node --test .github/workflows/scripts/release-embed.test.mts
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { buildAnnouncement } from './release-embed.mts';
+
+const repo = 'jsverse/transloco';
+
+const embedOf = (version: string, notes = '') =>
+  buildAnnouncement({ version, repo, notes }).embeds[0];
+
+describe('buildAnnouncement', () => {
+  it('given a stable version, then it announces the latest dist-tag', () => {
+    const embed = embedOf('9.0.0');
+
+    assert.equal(embed.title, '🎉 @jsverse/transloco v9.0.0');
+    assert.equal(embed.color, 0x2ecc71);
+    assert.equal(embed.fields[0].value, '`latest`');
+    assert.match(embed.description, /npm i @jsverse\/transloco@latest/);
+  });
+
+  it('given a prerelease version, then it announces the next dist-tag and is visually distinct', () => {
+    const embed = embedOf('9.0.0-alpha.1');
+
+    assert.equal(
+      embed.title,
+      '🧪 @jsverse/transloco v9.0.0-alpha.1 · prerelease',
+    );
+    assert.notEqual(embed.color, embedOf('9.0.0').color);
+    assert.equal(embed.fields[0].value, '`next`');
+    assert.match(embed.description, /npm i @jsverse\/transloco@next/);
+  });
+
+  // The tag is `releases/{version}`, so the permalink doubles that segment — writing the
+  // more natural /releases/tag/v9.0.0 ships a dead link.
+  it('given any version, then the release url keeps the doubled releases segment', () => {
+    assert.equal(
+      embedOf('9.0.0').url,
+      'https://github.com/jsverse/transloco/releases/tag/releases/9.0.0',
+    );
+  });
+
+  it('given notes, then they sit between the install block and the links', () => {
+    const embed = embedOf(
+      '9.0.0',
+      '### 🚀 Features\n\n- **transloco:** signals',
+    );
+
+    assert.equal(
+      embed.description,
+      '```bash\n' +
+        'npm i @jsverse/transloco@latest\n' +
+        '```\n' +
+        '### 🚀 Features\n\n- **transloco:** signals\n' +
+        '\n' +
+        '[Release notes](https://github.com/jsverse/transloco/releases/tag/releases/9.0.0)' +
+        ' · [Changelog](https://github.com/jsverse/transloco/blob/master/CHANGELOG.md)' +
+        ' · [npm](https://www.npmjs.com/package/@jsverse/transloco/v/9.0.0)',
+    );
+  });
+
+  it('given no notes, then the embed still carries the links', () => {
+    const embed = embedOf('9.0.0');
+
+    assert.match(embed.description, /\[Release notes\]/);
+    assert.ok(embed.description.length < 4096);
+  });
+
+  it('given notes hostile to JSON, then the payload survives a round trip', () => {
+    const notes = '- **transloco:** a "quoted" \\ backslashed 🚀 line';
+    const payload = buildAnnouncement({ version: '9.0.0', repo, notes });
+
+    const roundTripped = JSON.parse(JSON.stringify(payload));
+    assert.match(
+      roundTripped.embeds[0].description,
+      /a "quoted" \\ backslashed 🚀/,
+    );
+  });
+
+  it('given oversized notes, then the description stays inside the Discord limit', () => {
+    const notes = '🚀 a long emoji-laden release note line\n'.repeat(200);
+    const embed = embedOf('9.0.0', notes);
+
+    assert.ok(embed.description.length < 4096);
+    assert.match(embed.description, /…/);
+    // Truncating by code point must not leave half an emoji behind.
+    assert.ok(embed.description.isWellFormed());
+  });
+});

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,8 @@ Tests follow given-when-then format (per recent commit convention).
 
 All packages use fixed versioning (bump together). Conventional commits drive semantic version bumps. Tag pattern: `releases/{version}`.
 
+Real (non-dry-run) releases are announced in Discord `#releases` by `.github/workflows/scripts/announce-release.mts`, posting to the webhook in the `DISCORD_RELEASES_WEBHOOK` secret. Best-effort: it self-skips when the secret is unset, and the step is `continue-on-error`.
+
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] CI related changes

## What is the current behavior?

Issue Number: N/A

Releases are announced nowhere. Anyone who wants to know that a version shipped has to watch the repo, poll npm, or notice the changelog.

## What is the new behavior?

`release.yml` gains a 14-line final step that runs `.github/workflows/scripts/announce-release.mts`, posting a Discord embed once a real (non-dry-run) release completes.

The embed carries what matters for an npm library — version, resolved dist-tag, and a copy-pasteable install line — plus the release notes and links out:

- **Stable** — green, `🎉 @jsverse/transloco v9.0.0`, `npm i @jsverse/transloco@latest`
- **Prerelease** — orange, `🧪 @jsverse/transloco v9.0.0-alpha.1 · prerelease`, `npm i @jsverse/transloco@next`

Notes come from the GitHub Release created by the Changelog step, truncated to 1400 code points, followed by `Release notes · Changelog · npm`.

### Layout

Mirrors the existing `label-issues` trio — a pure module, a runner, and a `node --test` sibling:

| File | Role |
| --- | --- |
| `scripts/release-embed.mts` | Pure payload builder, no I/O |
| `scripts/announce-release.mts` | Reads env, fetches notes, POSTs |
| `scripts/release-embed.test.mts` | 7 unit tests |

Run with plain `node` under Node 24's type stripping, like `label-issues.mts` and `tools/scripts/*.mts` — no `tsx`, no loader, nothing to install.

### Design notes

**It can never fail a release.** The step is last, after Publish, and `continue-on-error`. By then the tag is on master and the tarballs are on npm; a Discord outage must not turn a successful release red and tempt a re-run. It also inherits GitHub's implicit `success()`, so a failed tag push or changelog step skips it rather than announcing a release that never landed.

**It self-skips without configuration.** With `DISCORD_RELEASES_WEBHOOK` unset it logs a notice and exits 0, so forks and fresh clones release normally.

**The release URL has a doubled path segment.** The tag pattern is `releases/{version}`, so the permalink is `/releases/tag/releases/9.0.0`, not `/releases/tag/v9.0.0`. Verified to return 200 against a real tag, and pinned by a test.

**Truncation is by code point**, so an emoji can never be cut in half — asserted via `isWellFormed()`.

## Verification

- `node --test .github/workflows/scripts/release-embed.test.mts` — 7/7 pass.
- The runner was executed end to end against a local stub GitHub API and stub webhook across six scenarios, all correct:

| Scenario | Result |
| --- | --- |
| Stable release | Green embed, `latest`, exit 0 |
| Prerelease | Orange embed, `next`, prerelease label, exit 0 |
| Secret absent | Notice, exit 0, nothing posted |
| Notes fetch 404s | Warning, still posts with links, exit 0 |
| Discord returns 429 | Warning, non-fatal via `continue-on-error` |
| `VERSION` unset | Warning, nothing posted |

- `actionlint` (with the repo's config) and Prettier clean.
- Discord's actual rendering is untested — there is no webhook URL yet. The payload is valid JSON well inside the documented embed limits; the first real release is the render test.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

One manual setup step remains, and it can't be done from the repo:

1. **Discord** — `#releases` → Edit Channel → Integrations → Webhooks → New Webhook → Copy Webhook URL
2. **GitHub** — repo Settings → Secrets and variables → Actions → new repository secret named `DISCORD_RELEASES_WEBHOOK`

Until that secret exists the step self-skips, so this is safe to merge before the Discord side is ready.

Worth noting separately: neither `release-embed.test.mts` nor the existing `package-labels.test.mts` runs in CI — both are manual `node --test` invocations. Wiring the two into a CI job is a reasonable follow-up, kept out of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Releases are now announced automatically in the Discord releases channel after successful publication.
  - Announcements include release notes, version details, relevant links, installation guidance, and the appropriate stable or prerelease distribution tag.
  - Notifications are skipped when no webhook is configured and won’t block releases if Discord is unavailable.

- **Documentation**
  - Added guidance describing the release announcement process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->