### PR TITLE
fix(transloco): avoid duplicate fallback lang request when already cached

### DIFF
--- a/libs/transloco/src/lib/tests/service/missingHandler.spec.ts
+++ b/libs/transloco/src/lib/tests/service/missingHandler.spec.ts
@@ -1,7 +1,9 @@
 import { fakeAsync } from '@angular/core/testing';
+import { map, timer } from 'rxjs';
 
-import { createService, runLoader } from '../mocks';
+import { createService, mockLangs, runLoader } from '../mocks';
 import { TranslocoService } from '../../transloco.service';
+import { TranslocoLoader } from '../../transloco.loader';
 
 describe('missingHandler', () => {
   describe('missingHandler.allowEmpty', () => {
@@ -94,6 +96,48 @@ describe('missingHandler', () => {
       service.load('en').subscribe();
       runLoader(2000);
       expect(service.translate('empty', { value: 'hello' })).toEqual('');
+    }));
+  });
+
+  describe('useFallbackTranslation - no duplicate request', () => {
+    it(`GIVEN fallback lang is already cached
+        WHEN loading another lang with useFallbackTranslation
+        THEN should not make a duplicate request for the fallback lang`, fakeAsync(() => {
+      // Record every lang the loader is actually asked to fetch, so we can
+      // assert on real requests instead of spying on service internals.
+      const requestedLangs: string[] = [];
+
+      class RecordingLoader implements TranslocoLoader {
+        getTranslation(lang: string) {
+          requestedLangs.push(lang);
+          return timer(1000).pipe(map(() => mockLangs[lang]));
+        }
+      }
+
+      const service = createService(
+        {
+          // defaultLang and fallbackLang both default to 'en' in createService.
+          missingHandler: { useFallbackTranslation: true },
+        },
+        { loader: RecordingLoader },
+      );
+
+      // Loads 'en' as the default lang -> fetched once.
+      service.load('en').subscribe();
+      runLoader();
+
+      // Loads 'es'; its fallback is 'en', which is already cached, so only
+      // 'es' should hit the loader here.
+      service.load('es').subscribe();
+      runLoader();
+
+      expect(requestedLangs).toEqual(['en', 'es']);
+      // 'es' resolved from its own file, and a key missing in 'es' still
+      // falls back to the cached 'en'.
+      expect(service.translate('home', {}, 'es')).toEqual('home spanish');
+      expect(service.translate('key.is.like.path', {}, 'es')).toEqual(
+        'key is like path',
+      );
     }));
   });
 });

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -301,11 +301,38 @@ export class TranslocoService {
         ? `${scope!}/${this.firstFallbackLang}`
         : this.firstFallbackLang;
 
-      const loaders = getFallbacksLoaders({
-        ...loadersOptions,
-        fallbackPath: fallback!,
-      });
-      loadTranslation = forkJoin(loaders);
+      const cachedFallback = this.cache.get(fallback!);
+      if (cachedFallback) {
+        // We already have the fallback lang in the cache (it's either still
+        // loading or fully loaded), so there's no need to ask the loader for it
+        // again. `getFallbacksLoaders` doesn't look at the cache, so calling it
+        // here would fire a second HTTP request for a file we already have.
+        //
+        // For example, with `defaultLang: 'en'`, `fallbackLang: 'en'` and
+        // `useFallbackTranslation` on:
+        //   1. load('en') -> not cached -> GET en.json (now cached)
+        //   2. load('es') -> fallback is 'en' -> reuse the cached 'en' instead
+        //      of fetching en.json again, and only GET es.json.
+        //
+        // So we build the two loaders by hand: fetch the requested lang, and
+        // reuse the cached fallback observable for the fallback lang.
+        const primaryLoader = from(resolveLoader(loadersOptions)).pipe(
+          map((translation) => ({ translation, lang: path })),
+        );
+        const fallbackLoader = cachedFallback.pipe(
+          map(() => ({
+            translation: this.getTranslation(fallback!),
+            lang: fallback!,
+          })),
+        );
+        loadTranslation = forkJoin([primaryLoader, fallbackLoader]);
+      } else {
+        const loaders = getFallbacksLoaders({
+          ...loadersOptions,
+          fallbackPath: fallback!,
+        });
+        loadTranslation = forkJoin(loaders);
+      }
     } else {
       const loader = resolveLoader(loadersOptions);
       loadTranslation = from(loader);


### PR DESCRIPTION
When `useFallbackTranslation` is enabled, loading a secondary language
(e.g. 'es') would internally call `getFallbacksLoaders`, which invokes
`resolveLoader` directly — bypassing the service cache. This caused a
duplicate HTTP request for the fallback lang whenever it had already been
fetched (e.g. as the default lang).

Fix: before delegating to `getFallbacksLoaders`, check whether the
fallback lang's observable is already in the cache. If it is, reuse it
via a mapped `forkJoin` instead of issuing a new network request.

Adds a regression test covering the case where `fallbackLang` matches
`defaultLang` and a second language is loaded afterward.

Closes #625 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate requests for fallback translations when the fallback language is already cached.
  - Improved language loading behavior when fallback translation support is enabled, reducing unnecessary network activity while preserving fallback content.
- **Tests**
  - Added coverage confirming cached fallback translations are reused correctly during language changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->