### PR TITLE
fix(validator): support UTF-8 BOM in translation files

### DIFF
--- a/libs/transloco-validator/src/lib/transloco-validator.spec.ts
+++ b/libs/transloco-validator/src/lib/transloco-validator.spec.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import validator from './transloco-validator';
+
+const BOM = '\uFEFF';
+
+describe('transloco-validator', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'transloco-validator-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(name: string, content: string) {
+    const filePath = path.join(dir, name);
+    fs.writeFileSync(filePath, content, 'utf-8');
+    return filePath;
+  }
+
+  it(`GIVEN a JSON file prefixed with a UTF-8 BOM
+      WHEN it is validated
+      THEN it does not throw`, () => {
+    const file = write('en.json', `${BOM}{"hello": "world"}`);
+
+    expect(() => validator([file])).not.toThrow();
+  });
+
+  it(`GIVEN a BOM-prefixed JSON file with duplicate keys
+      WHEN it is validated
+      THEN it still reports the duplicate keys`, () => {
+    const file = write('en.json', `${BOM}{"a": "1", "a": "2"}`);
+
+    expect(() => validator([file])).toThrow(/duplicate keys/i);
+  });
+
+  it(`GIVEN a plain JSON file without a BOM
+      WHEN it is validated
+      THEN it does not throw`, () => {
+    const file = write('en.json', '{"hello": "world"}');
+
+    expect(() => validator([file])).not.toThrow();
+  });
+
+  it(`GIVEN a malformed JSON file
+      WHEN it is validated
+      THEN it throws`, () => {
+    const file = write('en.json', '{"hello": }');
+
+    expect(() => validator([file])).toThrow();
+  });
+});

--- a/libs/transloco-validator/src/lib/transloco-validator.ts
+++ b/libs/transloco-validator/src/lib/transloco-validator.ts
@@ -4,7 +4,8 @@ import findDuplicatedPropertyKeys from 'find-duplicated-property-keys';
 
 export default function (translationFilePaths: string[]) {
   translationFilePaths.forEach((path) => {
-    const translation = fs.readFileSync(path, 'utf-8');
+    // Strip a leading BOM - some editors add one and it breaks JSON.parse.
+    const translation = fs.readFileSync(path, 'utf-8').replace(/^\uFEFF/, '');
 
     // Verify that we can parse the JSON
     JSON.parse(translation);


### PR DESCRIPTION
Some editors save JSON files with a hidden BOM character at the very start. The validator choked on those files with a confusing "unexpected character at position 0" error. Now it strips that character before checking the file, so BOM files pass while bad JSON is still rejected.

Closes #609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Translation files beginning with a UTF-8 byte-order mark are now validated correctly.
  * Duplicate-key detection and malformed JSON error reporting continue to work as expected.

* **Tests**
  * Added coverage for BOM-prefixed, standard, duplicate-key, and malformed translation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->