### PR TITLE
fix(transloco): accept a scope in selectTranslateObject lang argument

### DIFF
--- a/libs/transloco/src/lib/tests/service/selectTranslateObject.spec.ts
+++ b/libs/transloco/src/lib/tests/service/selectTranslateObject.spec.ts
@@ -41,6 +41,16 @@ describe('selectTranslateObject', () => {
       expect(spy).toHaveBeenCalledWith({ a: { b: 'a.b spanish' } });
     }));
 
+    it(`GIVEN a scope object for a file that has not been loaded
+        WHEN subscribing to selectTranslateObject with that scope object
+        THEN should load the scope file and emit the translation object`, fakeAsync(() => {
+      service
+        .selectTranslateObject('obj', {}, { scope: 'lazy-page' })
+        .subscribe(spy);
+      runLoader();
+      expect(spy).toHaveBeenCalledWith({ a: { b: 'a.b english' } });
+    }));
+
     it(`GIVEN a TranslocoService with English translations loaded
         WHEN subscribing to selectTranslateObject with a nested path key
         THEN should emit the nested translation object`, fakeAsync(() => {

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -506,20 +506,30 @@ export class TranslocoService {
     return translations;
   }
 
+  /**
+   * Load the translation file (if not loaded yet) and behaves the same as translateObject.
+   *
+   * @example
+   *
+   * selectTranslateObject<string>('someObject').subscribe(value => ...)
+   * selectTranslateObject('someObject', {}, 'es').subscribe(value => ...)
+   * selectTranslateObject('someObject', {}, 'todos').subscribe(value => ...)
+   * selectTranslateObject('someObject', {}, { scope: 'todos' }).subscribe(value => ...)
+   */
   selectTranslateObject<T = any>(
     key: string,
     params?: HashMap,
-    lang?: string,
+    lang?: string | TranslocoScope | TranslocoScope[],
   ): Observable<T>;
   selectTranslateObject<T = any>(
     key: string[],
     params?: HashMap,
-    lang?: string,
+    lang?: string | TranslocoScope | TranslocoScope[],
   ): Observable<T[]>;
   selectTranslateObject<T = any>(
     key: TranslateParams,
     params?: HashMap,
-    lang?: string,
+    lang?: string | TranslocoScope | TranslocoScope[],
   ): Observable<T> | Observable<T[]>;
   selectTranslateObject<T = any>(
     key: HashMap | Map<string, HashMap>,
@@ -529,21 +539,28 @@ export class TranslocoService {
   selectTranslateObject<T = any>(
     key: TranslateObjectParams,
     params?: HashMap | null,
-    lang?: string,
+    lang?: string | TranslocoScope | TranslocoScope[],
   ): Observable<T> | Observable<T[]> {
     if (isString(key) || Array.isArray(key)) {
       return this.selectTranslate<T>(key, params!, lang, true);
     }
 
+    // The key-map form has no scope argument, so `lang` is always a plain string here.
+    const stringLang = lang as string | undefined;
+
     const [[firstKey, firstParams], ...rest] = this.getEntries(key);
 
     /* In order to avoid subscribing multiple times to the load language event by calling selectTranslateObject for each pair,
      * we listen to when the first key has been translated (the language is loaded) and translate the rest synchronously */
-    return this.selectTranslateObject<T>(firstKey, firstParams, lang).pipe(
+    return this.selectTranslateObject<T>(
+      firstKey,
+      firstParams,
+      stringLang,
+    ).pipe(
       map((value) => {
         const translations = [value];
         for (const [_key, _params] of rest) {
-          translations.push(this.translateObject<T>(_key, _params, lang));
+          translations.push(this.translateObject<T>(_key, _params, stringLang));
         }
 
         return translations;


### PR DESCRIPTION
At runtime selectTranslateObject already loads an unloaded scope file when you pass the scope as the third argument, but the type only allowed a plain string. That made the documented "loads the file if not loaded" behaviour unreachable without a cast when passing a { scope, loader } object.

Widen the string / string[] key overloads to accept string | TranslocoScope | TranslocoScope[], matching selectTranslate. The key-map overload is left as a plain string since that path does not support a scope.

Closes #529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Expanded `selectTranslateObject` to support scoped translations, including loading translations from unloaded scopes.
  * Added support for specifying one or multiple translation scopes when selecting translation objects.

* **Tests**
  * Added coverage confirming scoped translation objects load and emit the expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->