### PR TITLE
fix(transloco): strip a leading BOM in keys-manager and optimize

### DIFF
--- a/libs/transloco-keys-manager/src/lib/tests/file.utils.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/file.utils.spec.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { readFile } from '../utils/file.utils';
+
+const BOM = '\uFEFF';
+
+describe('readFile', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'transloco-keys-manager-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(name: string, content: string) {
+    const filePath = path.join(dir, name);
+    fs.writeFileSync(filePath, content, 'utf-8');
+
+    return filePath;
+  }
+
+  it(`GIVEN a JSON file prefixed with a UTF-8 BOM
+      WHEN it is read with parse: true
+      THEN it is parsed instead of throwing`, () => {
+    const file = write('en.json', `${BOM}{"hello": "world"}`);
+
+    expect(readFile(file, { parse: true })).toEqual({ hello: 'world' });
+  });
+
+  it(`GIVEN a plain JSON file without a BOM
+      WHEN it is read with parse: true
+      THEN it is parsed`, () => {
+    const file = write('en.json', '{"hello": "world"}');
+
+    expect(readFile(file, { parse: true })).toEqual({ hello: 'world' });
+  });
+
+  it(`GIVEN a malformed JSON file
+      WHEN it is read with parse: true
+      THEN it throws`, () => {
+    const file = write('en.json', '{"hello": }');
+
+    expect(() => readFile(file, { parse: true })).toThrow();
+  });
+
+  it(`GIVEN a file prefixed with a UTF-8 BOM
+      WHEN it is read without parsing
+      THEN the content is returned verbatim`, () => {
+    // Raw reads feed prettier, which writes the result back to the user's file,
+    // so the BOM is deliberately left alone outside the parse branch.
+    const file = write('en.json', `${BOM}{"hello": "world"}`);
+
+    expect(readFile(file)).toBe(`${BOM}{"hello": "world"}`);
+  });
+});

--- a/libs/transloco-keys-manager/src/lib/utils/file.utils.ts
+++ b/libs/transloco-keys-manager/src/lib/utils/file.utils.ts
@@ -15,7 +15,8 @@ export function readFile(
   const content = readFileSync(file, { encoding: 'utf-8' });
 
   if (parse) {
-    return JSON.parse(content);
+    // Strip a leading BOM - some editors add one and it breaks JSON.parse.
+    return JSON.parse(content.replace(/^\uFEFF/, ''));
   }
 
   return content;

--- a/libs/transloco-optimize/src/lib/transloco-optimize.spec.ts
+++ b/libs/transloco-optimize/src/lib/transloco-optimize.spec.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { optimizeFiles } from './transloco-optimize';
+
+const BOM = '\uFEFF';
+
+describe('optimizeFiles', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'transloco-optimize-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(name: string, content: string) {
+    const filePath = path.join(dir, name);
+    fs.writeFileSync(filePath, content, 'utf8');
+
+    return filePath;
+  }
+
+  function read(filePath: string) {
+    return fs.readFileSync(filePath, { encoding: 'utf8' });
+  }
+
+  it(`GIVEN a translation file prefixed with a UTF-8 BOM
+      WHEN it is optimized
+      THEN it is flattened instead of rejecting`, async () => {
+    const file = write('en.json', `${BOM}{"a": {"b": "c"}}`);
+
+    await expect(optimizeFiles([file], 'comment')).resolves.toBeUndefined();
+    expect(read(file)).toBe('{"a.b":"c"}');
+  });
+
+  it(`GIVEN a plain translation file without a BOM
+      WHEN it is optimized
+      THEN it is flattened and its comments are removed`, async () => {
+    const file = write('en.json', '{"a": {"b": "c", "comment": "drop me"}}');
+
+    await expect(optimizeFiles([file], 'comment')).resolves.toBeUndefined();
+    expect(read(file)).toBe('{"a.b":"c"}');
+  });
+
+  it(`GIVEN a malformed translation file
+      WHEN it is optimized
+      THEN it rejects`, async () => {
+    const file = write('en.json', '{"a": }');
+
+    await expect(optimizeFiles([file], 'comment')).rejects.toThrow();
+  });
+});

--- a/libs/transloco-optimize/src/lib/transloco-optimize.ts
+++ b/libs/transloco-optimize/src/lib/transloco-optimize.ts
@@ -37,7 +37,8 @@ export function optimizeFiles(translationPaths: string[], commentsKey: string) {
     for (const path of translationPaths) {
       try {
         const translation = fs.readFileSync(path, { encoding: 'utf8' });
-        const asObject = JSON.parse(translation);
+        // Strip a leading BOM - some editors add one and it breaks JSON.parse.
+        const asObject = JSON.parse(translation.replace(/^\uFEFF/, ''));
         const flatObject = flatten(asObject, { safe: true }) as Translation;
         const optimized = JSON.stringify(
           removeComments(flatObject, commentsKey),


### PR DESCRIPTION
Follow-up to #1000, which taught `transloco-validator` to strip a leading UTF-8 BOM before parsing a translation file. The sibling Node tools that read the same files were left with the original bug, so the toolchain was inconsistent: a translation file saved with a BOM would now pass validation and then still blow up further down the pipeline.

Concretely, before this PR:

```
$ transloco-validator src/assets/i18n/en.json   # passes since #1000
$ transloco-keys-manager find
SyntaxError: Unexpected token ... is not valid JSON
# (the offending token is the invisible BOM at offset 0)
```

## What changed

Two sites parse translation JSON out of a raw `readFileSync` result and so hit the same `SyntaxError`:

- `libs/transloco-keys-manager/src/lib/utils/file.utils.ts` — the `parse: true` branch of `readFile`, reached from `keys-detective/compare-keys-to-files.ts` and `webpack-plugin/generate-keys.ts`.
- `libs/transloco-optimize/src/lib/transloco-optimize.ts` — `optimizeFiles`.

Both now apply the same anchored `.replace(/^\uFEFF/, '')` that #1000 introduced, so the three CLI entry points agree on how they treat a BOM.

## Scope notes

- The strip is deliberately confined to the `parse` branch of `readFile`. Raw (unparsed) reads feed `run-prettier`, which writes its result back over the user's own file — stripping there would silently delete BOMs from source files people asked us to format. There is a spec pinning that behavior.
- `keys-builder/utils/get-current-translation.ts` is untouched: its `parseJson` goes through `fs-extra`'s `readJsonSync`, and `jsonfile` already strips the BOM. Verified rather than assumed.
- The browser runtime was never affected — XHR/fetch text decoding strips the BOM before Angular's `HttpXhrBackend` parses the response. This is a CLI-only gap.
- The schematics `JSON.parse` call sites are left alone; those read workspace/package config, not translation files.

## Verification

- New spec `libs/transloco-keys-manager/src/lib/tests/file.utils.spec.ts` (4 tests) and `libs/transloco-optimize/src/lib/transloco-optimize.spec.ts` (3 tests). `transloco-optimize` had no specs at all before this, and the suite runs with `passWithNoTests: true`, so the test count was confirmed to actually rise from 0 to 3 rather than the suite merely staying green.
- Mutation-tested each one-liner independently: reverting the `keys-manager` strip fails exactly its BOM spec (1 failed, 3 passed); reverting the `optimize` strip fails exactly its BOM spec (1 failed, 2 passed). Each spec guards its own site.
- Full suites green: `transloco-keys-manager` 222 passed / 1 skipped across 21 files, `transloco-optimize` 3 passed.
- `nx lint` clean for both projects (0 errors; the remaining warnings are pre-existing `no-explicit-any`).
- Both `tsconfig.lib.json` files already exclude `**/*.spec.ts`, so neither new spec is emitted into `dist` or the published packages.

Related to #609. Does not close it — #1000 is the PR that addresses the reported case; this only brings the sibling tools in line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Translation and JSON files with a leading UTF-8 BOM now parse and optimize correctly.
  * Existing handling of malformed JSON and raw file reads remains unchanged.

* **Tests**
  * Added coverage for BOM-prefixed files, standard JSON files, malformed JSON, comment removal, and raw content preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->