### PR TITLE
fix(messageformat): compile each string with its own language's rules

### DIFF
--- a/libs/transloco-messageformat/src/lib/messageformat.transpiler.spec.ts
+++ b/libs/transloco-messageformat/src/lib/messageformat.transpiler.spec.ts
@@ -1,9 +1,11 @@
 import {
   defaultConfig,
+  provideTransloco,
   provideTranslocoConfig,
   TRANSLOCO_TRANSPILER,
   translocoConfig,
   TranslocoConfig,
+  TranslocoService,
   TranspileParams,
 } from '@jsverse/transloco';
 import { CustomFormatter } from '@messageformat/core';
@@ -104,6 +106,97 @@ describe('MessageFormatTranspiler', () => {
     expect(
       transpiler.transpile(getTranspilerParams(polishKey, { params })),
     ).toBe('2 things');
+  });
+
+  describe('per-language compilation (#528)', () => {
+    const polishKey =
+      '{count, plural, =0 {none} one {# thing} few {# things} many {# things} other {# things}}';
+
+    it(`GIVEN a transpiler whose active locale is en
+        WHEN a Polish string is transpiled with lang: 'pl'
+        THEN it compiles with Polish plural rules instead of throwing`, () => {
+      const transpiler = getTranspiler({ locales: 'en' });
+
+      expect(
+        transpiler.transpile(
+          getTranspilerParams(polishKey, { params: { count: 2 }, lang: 'pl' }),
+        ),
+      ).toBe('2 things');
+    });
+
+    it(`GIVEN a string transpiled once with lang: 'pl'
+        WHEN the same string is transpiled again with no lang hint
+        THEN the hint does not leak and the active locale still applies`, () => {
+      const transpiler = getTranspiler({ locales: 'en' });
+
+      expect(
+        transpiler.transpile(
+          getTranspilerParams(polishKey, { params: { count: 2 }, lang: 'pl' }),
+        ),
+      ).toBe('2 things');
+      expect(() =>
+        transpiler.transpile(
+          getTranspilerParams(polishKey, { params: { count: 2 } }),
+        ),
+      ).toThrowError();
+    });
+
+    it(`GIVEN an object value with a nested messageformat string
+        WHEN transpiled with lang: 'pl'
+        THEN the lang hint reaches the nested compilation`, () => {
+      const transpiler = getTranspiler({ locales: 'en' });
+
+      expect(
+        transpiler.transpile(
+          getTranspilerParams(
+            { things: polishKey },
+            { params: { things: { count: 2 } }, lang: 'pl' },
+          ),
+        ),
+      ).toEqual({ things: '2 things' });
+    });
+
+    it(`GIVEN no lang hint
+        WHEN a string is transpiled
+        THEN it still uses the active locale`, () => {
+      const transpiler = getTranspiler({ locales: 'en' });
+
+      expect(() =>
+        transpiler.transpile(
+          getTranspilerParams(polishKey, { params: { count: 2 } }),
+        ),
+      ).toThrowError();
+    });
+  });
+
+  describe('fallback translation with differing plural rules (#528)', () => {
+    it(`GIVEN active lang ja (no 'one' plural) and an en fallback translation
+        WHEN a key missing in ja is translated
+        THEN the en fallback compiles with en plural rules`, () => {
+      const service = TestBed.configureTestingModule({
+        providers: [
+          provideTransloco({
+            config: translocoConfig({
+              availableLangs: ['en', 'ja'],
+              defaultLang: 'ja',
+              fallbackLang: 'en',
+              missingHandler: { useFallbackTranslation: true },
+            }),
+          }),
+          provideTranslocoMessageformat(),
+        ],
+      }).inject(TranslocoService);
+
+      service.setTranslation(
+        { items: '{count, plural, one {# item} other {# items}}' },
+        'en',
+        { emitChange: false },
+      );
+      service.setTranslation({}, 'ja', { emitChange: false });
+      service.setActiveLang('ja');
+
+      expect(service.translate('items', { count: 1 })).toBe('1 item');
+    });
   });
 });
 

--- a/libs/transloco-messageformat/src/lib/messageformat.transpiler.ts
+++ b/libs/transloco-messageformat/src/lib/messageformat.transpiler.ts
@@ -24,6 +24,9 @@ export class MessageFormatTranspiler extends DefaultTranspiler {
   private messageFormat: MessageFormat;
   private readonly messageConfig: MessageFormatOptions<'string'>;
   private readonly mfFactory: MFFactory;
+  // MessageFormat instances keyed by language, so a string is compiled with its
+  // own language's plural/select rules and not the active language's (#528).
+  private readonly messageFormatByLang = new Map<string, MessageFormat>();
 
   constructor(
     @Optional()
@@ -41,10 +44,12 @@ export class MessageFormatTranspiler extends DefaultTranspiler {
     this.messageFormat = this.mfFactory(locales, messageConfig);
   }
 
-  transpile({ value, params = {}, translation, key }: TranspileParams) {
+  transpile({ value, params = {}, translation, key, lang }: TranspileParams) {
     if (!value) {
       return value;
     }
+
+    const messageFormat = this.resolveMessageFormat(lang);
 
     if (isObject(value) && params) {
       Object.keys(params).forEach((p) => {
@@ -53,14 +58,21 @@ export class MessageFormatTranspiler extends DefaultTranspiler {
           params: getValue(params, p),
           translation,
           key,
+          lang,
         });
-        const message = this.messageFormat.compile(transpiled);
+        const message = messageFormat.compile(transpiled);
         value = setValue(value, p, message(params[p]));
       });
     } else if (!Array.isArray(value)) {
-      const transpiled = super.transpile({ value, params, translation, key });
+      const transpiled = super.transpile({
+        value,
+        params,
+        translation,
+        key,
+        lang,
+      });
 
-      const message = this.messageFormat.compile(transpiled);
+      const message = messageFormat.compile(transpiled);
       return message(params);
     }
 
@@ -73,5 +85,19 @@ export class MessageFormatTranspiler extends DefaultTranspiler {
 
   setLocale(locale: MFLocale) {
     this.messageFormat = this.mfFactory(locale, this.messageConfig);
+  }
+
+  private resolveMessageFormat(lang: string | undefined): MessageFormat {
+    if (!lang) {
+      return this.messageFormat;
+    }
+
+    let messageFormat = this.messageFormatByLang.get(lang);
+    if (!messageFormat) {
+      messageFormat = this.mfFactory(lang, this.messageConfig);
+      this.messageFormatByLang.set(lang, messageFormat);
+    }
+
+    return messageFormat;
   }
 }

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -386,6 +386,7 @@ export class TranslocoService {
       params,
       translation,
       key,
+      lang: resolveLang,
     });
   }
 
@@ -495,7 +496,13 @@ export class TranslocoService {
       /* If an empty object was returned we want to try and translate the key as a string and not an object */
       return isEmpty(value)
         ? this.translate(key, params!, lang)
-        : this.parser.transpile({ value, params: params!, translation, key });
+        : this.parser.transpile({
+            value,
+            params: params!,
+            translation,
+            key,
+            lang: resolveLang,
+          });
     }
 
     const translations: T[] = [];

--- a/libs/transloco/src/lib/transloco.transpiler.ts
+++ b/libs/transloco/src/lib/transloco.transpiler.ts
@@ -30,6 +30,13 @@ export interface TranspileParams<V = unknown> {
   params?: HashMap;
   translation: Translation;
   key: string;
+  /**
+   * The language the `value` belongs to. Transpilers that are locale-aware
+   * (e.g. messageformat) use it so a string is compiled with its own language's
+   * rules rather than the active language's — relevant for inline `lang` and
+   * fallback translations.
+   */
+  lang?: string;
 }
 
 @Injectable()
@@ -41,7 +48,12 @@ export class DefaultTranspiler implements TranslocoTranspiler {
     return resolveMatcher(this.config);
   }
 
-  transpile({ value, params = {}, translation, key }: TranspileParams): any {
+  transpile({
+    value,
+    params = {},
+    translation,
+    ...rest
+  }: TranspileParams): any {
     if (isString(value)) {
       let paramMatch: RegExpExecArray | null;
       let parsedValue = value;
@@ -62,8 +74,8 @@ export class DefaultTranspiler implements TranslocoTranspiler {
             ? this.transpile({
                 params,
                 translation,
-                key,
                 value: translation[match],
+                ...rest,
               })
             : '';
         });
@@ -76,10 +88,10 @@ export class DefaultTranspiler implements TranslocoTranspiler {
           value,
           params,
           translation,
-          key,
+          ...rest,
         });
       } else if (Array.isArray(value)) {
-        value = this.handleArray({ value, params, translation, key });
+        value = this.handleArray({ value, params, translation, ...rest });
       }
     }
 
@@ -114,7 +126,7 @@ export class DefaultTranspiler implements TranslocoTranspiler {
     value,
     params = {},
     translation,
-    key,
+    ...rest
   }: TranspileParams<Record<any, any>>) {
     let result = value;
 
@@ -126,7 +138,7 @@ export class DefaultTranspiler implements TranslocoTranspiler {
         // get the params of "b.c" => { value: "Transloco" }
         params: getValue(params, p),
         translation,
-        key,
+        ...rest,
       });
 
       // set "b.c" to `transpiled`


### PR DESCRIPTION
The messageformat transpiler kept a single MessageFormat bound to the active language, so a string coming from another language - an inline `lang: 'xx|static'` block, or a fallback translation - was compiled with the wrong plural/select rules and threw "Invalid key" errors.

Transpile params now carry the string's language: a new optional `lang` on TranspileParams, set by TranslocoService.translate / translateObject and forwarded through DefaultTranspiler. The messageformat transpiler keeps one MessageFormat per language and picks the matching one per call; with no language given it uses the active locale as before.

Closes #528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Translation formatting now consistently applies the correct pluralization rules for the language associated with each translation.
  * Fallback translations use their own language’s formatting rules, including when the active language differs.
  * Language settings are preserved when formatting nested objects and arrays.
  * Per-translation language hints no longer affect subsequent translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->