### PR TITLE
fix(keys-manager): derive source root when project.json omits sourceRoot

### DIFF
--- a/libs/transloco-keys-manager/src/lib/tests/resolveProjectBasePath.spec.ts
+++ b/libs/transloco-keys-manager/src/lib/tests/resolveProjectBasePath.spec.ts
@@ -256,6 +256,39 @@ describe('resolveProjectBasePath', () => {
     );
   });
 
+  describe('Modern Nx project.json without sourceRoot', () => {
+    afterEach(() => {
+      removeProjectConfig('libs/modern');
+    });
+
+    it('derives the source root from the project directory', () => {
+      addProjectConfig({
+        path: 'libs/modern',
+        config: { name: 'modern-lib', projectType: 'library' },
+      });
+
+      const { projectBasePath, projectType } =
+        resolveProjectBasePath('modern-lib');
+      expect(projectBasePath).toBe('libs/modern/src');
+      expect(projectType).toBe('library');
+    });
+
+    it('honors an explicit root field over the directory', () => {
+      addProjectConfig({
+        path: 'libs/modern',
+        config: {
+          name: 'modern-lib',
+          projectType: 'library',
+          root: 'libs/xyz',
+        },
+      });
+
+      expect(resolveProjectBasePath('modern-lib').projectBasePath).toBe(
+        'libs/xyz/src',
+      );
+    });
+  });
+
   describe('Malformed configs', () => {
     const healthy = 'libs/healthy';
     const broken = 'libs/broken';

--- a/libs/transloco-keys-manager/src/lib/utils/resolve-project-base-path.ts
+++ b/libs/transloco-keys-manager/src/lib/utils/resolve-project-base-path.ts
@@ -122,6 +122,16 @@ function resolveProjectConfig(projectName?: string) {
 
       const config = parseProjectConfig(configPath, content);
 
+      if (config && !config.sourceRoot) {
+        // Modern Nx `project.json` files usually omit `sourceRoot`; Nx defaults
+        // it to `<projectRoot>/src`. Without this the base path falls back to the
+        // workspace-root `src`, so keys in libs go undetected (#952).
+        const projectRoot =
+          config.root || path.dirname(configPath).replace(/\\/g, '/');
+        config.sourceRoot =
+          projectRoot && projectRoot !== '.' ? `${projectRoot}/src` : 'src';
+      }
+
       if (config?.name === projectName) {
         return config;
       }


### PR DESCRIPTION
Modern Nx `project.json` files often don't set `sourceRoot`. When it was missing, `resolveProjectBasePath` silently fell back to the workspace-root `src`, so `find` / `extract` scanned nothing in that project - template keys in libs went undetected and their existing translations were reported as extra keys.

The source root is now derived from the project's own directory (or its explicit `root` field), the same way Nx defaults it.

Fixes #952

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project path resolution for modern Nx configurations that omit `sourceRoot`.
  * Correctly derives source directories from the project location or explicit project root.
  * Prevents projects from incorrectly falling back to the workspace-level `src` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->