### PR TITLE
feat(validator): flag unbalanced interpolation braces

### DIFF
--- a/libs/transloco-validator/src/lib/transloco-validator.spec.ts
+++ b/libs/transloco-validator/src/lib/transloco-validator.spec.ts
@@ -56,4 +56,48 @@ describe('transloco-validator', () => {
 
     expect(() => validator([file])).toThrow();
   });
+
+  it(`GIVEN a value with a missing curly brace
+      WHEN it is validated
+      THEN it throws naming the offending key`, () => {
+    const file = write(
+      'en.json',
+      JSON.stringify({
+        title: 'Created by { first }} {{ last }}',
+      }),
+    );
+
+    expect(() => validator([file])).toThrow(/title/);
+  });
+
+  it(`GIVEN a nested value with an extra closing brace
+      WHEN it is validated
+      THEN it throws with the full key path`, () => {
+    const file = write('en.json', JSON.stringify({ a: { b: 'hello }}' } }));
+
+    expect(() => validator([file])).toThrow(/a\.b/);
+  });
+
+  it(`GIVEN a value inside an array with unbalanced braces
+      WHEN it is validated
+      THEN it throws`, () => {
+    const file = write('en.json', JSON.stringify({ list: ['ok', '{{ x }'] }));
+
+    expect(() => validator([file])).toThrow(/list\[1]/);
+  });
+
+  it(`GIVEN values with balanced interpolation and ICU braces
+      WHEN it is validated
+      THEN it does not throw`, () => {
+    const file = write(
+      'en.json',
+      JSON.stringify({
+        interpolation: '{{ first }} {{ last }}',
+        icu: '{count, plural, one {# item} other {# items}}',
+        plain: 'no braces here',
+      }),
+    );
+
+    expect(() => validator([file])).not.toThrow();
+  });
 });

--- a/libs/transloco-validator/src/lib/transloco-validator.ts
+++ b/libs/transloco-validator/src/lib/transloco-validator.ts
@@ -8,7 +8,7 @@ export default function (translationFilePaths: string[]) {
     const translation = fs.readFileSync(path, 'utf-8').replace(/^\uFEFF/, '');
 
     // Verify that we can parse the JSON
-    JSON.parse(translation);
+    const parsed = JSON.parse(translation);
 
     // Verify that we don't have any duplicate keys
     const result = findDuplicatedPropertyKeys(translation);
@@ -17,5 +17,46 @@ export default function (translationFilePaths: string[]) {
         `Found duplicate keys: ${result.map(({ key }) => key)} (${path})`,
       );
     }
+
+    // Catch a missing/extra interpolation brace before it fails at runtime with
+    // an opaque parser error.
+    const unbalanced = findUnbalancedBraces(parsed);
+    if (unbalanced.length) {
+      throw new Error(
+        `Found unbalanced interpolation braces (${path}):\n${unbalanced.join(
+          '\n',
+        )}`,
+      );
+    }
   });
+}
+
+/**
+ * Returns one `keyPath: "value"` line per string whose `{` / `}` counts differ,
+ * ready to drop into the error message.
+ *
+ * Counting is enough: valid `{{ }}` and ICU `{ }` are both balanced, so a
+ * mismatch means a dropped or doubled brace. It won't catch transposed braces
+ * that still balance, and a deliberate lone brace in copy is a false positive.
+ */
+function findUnbalancedBraces(value: unknown, keyPath = ''): string[] {
+  if (typeof value === 'string') {
+    const open = (value.match(/{/g) ?? []).length;
+    const close = (value.match(/}/g) ?? []).length;
+    return open === close ? [] : [`  ${keyPath}: ${JSON.stringify(value)}`];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item, i) =>
+      findUnbalancedBraces(item, `${keyPath}[${i}]`),
+    );
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.entries(value).flatMap(([key, item]) =>
+      findUnbalancedBraces(item, keyPath ? `${keyPath}.${key}` : key),
+    );
+  }
+
+  return [];
 }


### PR DESCRIPTION
A missing or extra curly brace in a translation value, e.g. "Created by { first }} {{ last }}", only surfaced at runtime as an opaque parser SyntaxError. The validator now walks every string value and fails when the { and } counts don't match, naming the file and the key path.

Closes #493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Translation validation now detects unbalanced interpolation or ICU braces in nested objects and arrays.
  * Error messages identify the affected translation key and value.
  * Valid translations with properly balanced braces continue to pass validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->