### PR TITLE
fix(transloco): type the optional loader constructor param as nullable

### DIFF
--- a/libs/transloco/src/lib/tests/service/extend-service.spec.ts
+++ b/libs/transloco/src/lib/tests/service/extend-service.spec.ts
@@ -1,0 +1,43 @@
+import { inject, Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { TranslocoService } from '../../transloco.service';
+import { TRANSLOCO_LOADER } from '../../transloco.loader';
+import { TRANSLOCO_TRANSPILER } from '../../transloco.transpiler';
+import { TRANSLOCO_MISSING_HANDLER } from '../../transloco-missing-handler';
+import { TRANSLOCO_INTERCEPTOR } from '../../transloco.interceptor';
+import { TRANSLOCO_CONFIG } from '../../transloco.config';
+import { TRANSLOCO_FALLBACK_STRATEGY } from '../../transloco-fallback-strategy';
+import { provideTransloco } from '../../transloco.providers';
+
+@Injectable()
+class CustomTranslocoService extends TranslocoService {
+  constructor() {
+    // The loader is @Optional(); `inject(..., { optional: true })` returns
+    // `TranslocoLoader | null` and must pass straight through without a `!`.
+    super(
+      inject(TRANSLOCO_LOADER, { optional: true }),
+      inject(TRANSLOCO_TRANSPILER),
+      inject(TRANSLOCO_MISSING_HANDLER),
+      inject(TRANSLOCO_INTERCEPTOR),
+      inject(TRANSLOCO_CONFIG),
+      inject(TRANSLOCO_FALLBACK_STRATEGY),
+    );
+  }
+}
+
+describe('extending TranslocoService', () => {
+  it(`GIVEN a subclass forwarding the optional loader to super()
+      WHEN it is instantiated without a provided loader
+      THEN it constructs and translates via the default loader`, () => {
+    const service = TestBed.configureTestingModule({
+      providers: [
+        provideTransloco({ config: { availableLangs: ['en'] } }),
+        CustomTranslocoService,
+      ],
+    }).inject(CustomTranslocoService);
+
+    service.setTranslation({ key: 'value' }, 'en');
+    expect(service.translate('key')).toBe('value');
+  });
+});

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -152,6 +152,7 @@ export class TranslationLoadError extends Error {
 export class TranslocoService {
   langChanges$: Observable<string>;
 
+  private loader: TranslocoLoader;
   private translations = new Map<string, Translation>();
   private cache = new Map<string, Observable<Translation>>();
   private firstFallbackLang: string | undefined;
@@ -182,7 +183,7 @@ export class TranslocoService {
   private destroyed = false;
 
   constructor(
-    @Optional() @Inject(TRANSLOCO_LOADER) private loader: TranslocoLoader,
+    @Optional() @Inject(TRANSLOCO_LOADER) loader: TranslocoLoader | null,
     @Inject(TRANSLOCO_TRANSPILER) private parser: TranslocoTranspiler,
     @Inject(TRANSLOCO_MISSING_HANDLER)
     private missingHandler: TranslocoMissingHandler,
@@ -191,9 +192,7 @@ export class TranslocoService {
     @Inject(TRANSLOCO_FALLBACK_STRATEGY)
     private fallbackStrategy: TranslocoFallbackStrategy,
   ) {
-    if (!this.loader) {
-      this.loader = new DefaultLoader(this.translations);
-    }
+    this.loader = loader ?? new DefaultLoader(this.translations);
     this.config = JSON.parse(JSON.stringify(userConfig));
 
     this.setAvailableLangs(this.config.availableLangs || []);


### PR DESCRIPTION
`TRANSLOCO_LOADER` is `@Optional()`, so Angular passes `null` when no loader is registered, but the parameter was typed `TranslocoLoader`. A subclass forwarding `inject(TRANSLOCO_LOADER, { optional: true })` to `super()` had to add a non-null assertion to compile.

Widen the parameter to `TranslocoLoader | null`; `this.loader` stays non-null through the existing default-loader fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `TranslocoService` extension so subclasses can be instantiated without explicitly providing a loader.
  * Ensured translation continues to use the default loader when no custom loader is available.

* **Tests**
  * Added coverage verifying optional loader injection and default translation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->