### PR TITLE
fix(locale): drop conflicting date options when merging the global config

### DIFF
--- a/libs/transloco-locale/src/lib/pipes/transloco-date.pipe.ts
+++ b/libs/transloco-locale/src/lib/pipes/transloco-date.pipe.ts
@@ -1,7 +1,7 @@
 import { inject, Pipe, PipeTransform } from '@angular/core';
 import { isNil } from '@jsverse/utils';
 
-import { getDefaultOptions } from '../shared';
+import { getDefaultOptions, mergeDateOptions } from '../shared';
 import { TRANSLOCO_LOCALE_CONFIG } from '../transloco-locale.config';
 import {
   DateFormatOptions,
@@ -37,9 +37,13 @@ export class TranslocoDatePipe extends BaseLocalePipe implements PipeTransform {
     if (isNil(date)) return '';
     locale = this.getLocale(locale);
 
-    return this.localeService.localizeDate(date, locale, {
-      ...getDefaultOptions(locale, 'date', this.localeConfig),
-      ...options,
-    });
+    return this.localeService.localizeDate(
+      date,
+      locale,
+      mergeDateOptions(
+        getDefaultOptions(locale, 'date', this.localeConfig),
+        options,
+      ),
+    );
   }
 }

--- a/libs/transloco-locale/src/lib/shared.ts
+++ b/libs/transloco-locale/src/lib/shared.ts
@@ -1,4 +1,5 @@
 import {
+  DateFormatOptions,
   Locale,
   LocaleFormatOptions,
   LocaleConfig,
@@ -18,4 +19,42 @@ export function getDefaultOptions<T extends keyof LocaleFormatOptions>(
   return Reflect.has(settings, style)
     ? { ...defaultConfig, ...settings[style] }
     : defaultConfig;
+}
+
+const DATE_STYLE_KEYS = ['dateStyle', 'timeStyle'];
+const DATE_COMPONENT_KEYS = [
+  'weekday',
+  'era',
+  'year',
+  'month',
+  'day',
+  'dayPeriod',
+  'hour',
+  'minute',
+  'second',
+  'fractionalSecondDigits',
+  'timeZoneName',
+];
+
+/**
+ * `Intl.DateTimeFormat` throws when `dateStyle`/`timeStyle` are combined with
+ * explicit component options (`year`, `hour`, ...). Spreading the global config
+ * over the pipe params can produce exactly that mix, so drop whichever group the
+ * caller's params conflict with before merging; non-conflicting keys such as
+ * `timeZone` are kept either way.
+ */
+export function mergeDateOptions(
+  defaults: DateFormatOptions,
+  options: DateFormatOptions,
+): DateFormatOptions {
+  const uses = (keys: string[]) =>
+    keys.some((key) => options[key as keyof DateFormatOptions] !== undefined);
+
+  const merged: Record<string, unknown> = { ...defaults };
+  const drop = (keys: string[]) => keys.forEach((key) => delete merged[key]);
+
+  if (uses(DATE_COMPONENT_KEYS)) drop(DATE_STYLE_KEYS);
+  if (uses(DATE_STYLE_KEYS)) drop(DATE_COMPONENT_KEYS);
+
+  return { ...merged, ...options };
 }

--- a/libs/transloco-locale/src/lib/tests/pipes/transloco-date.pipe.spec.ts
+++ b/libs/transloco-locale/src/lib/tests/pipes/transloco-date.pipe.spec.ts
@@ -92,6 +92,60 @@ describe('TranslocoDatePipe', () => {
     expect(timeStyle).toEqual('medium');
   });
 
+  it(`GIVEN a global dateStyle/timeStyle config
+      WHEN the pipe passes explicit component options
+      THEN the styles are dropped so Intl does not reject the combination`, () => {
+    spectator = pipeFactory(`{{ date | translocoDate:config }}`, {
+      hostProps: {
+        date,
+        config: { year: 'numeric', month: 'long', day: 'numeric' },
+      },
+      providers: [provideTranslocoLocaleConfigMock(LOCALE_CONFIG_MOCK)],
+    });
+    const [, options] = getIntlCallArgs(intlSpy);
+    expect(options).toEqual({
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    expect(spectator.element).toHaveText('October 7, 2019');
+  });
+
+  it(`GIVEN a global config of explicit component options
+      WHEN the pipe passes dateStyle
+      THEN the component options are dropped in favour of the style`, () => {
+    spectator = pipeFactory(`{{ date | translocoDate:config }}`, {
+      hostProps: {
+        date,
+        config: { dateStyle: 'medium' },
+      },
+      providers: [
+        provideTranslocoLocaleConfigMock({
+          global: {
+            date: { year: 'numeric', month: 'long', timeZone: 'UTC' },
+          },
+        }),
+      ],
+    });
+    const [, options] = getIntlCallArgs(intlSpy);
+    expect(options).toEqual({ dateStyle: 'medium', timeZone: 'UTC' });
+  });
+
+  it(`GIVEN a global config with a non-conflicting option
+      WHEN the pipe passes only a style
+      THEN the non-conflicting global option is kept`, () => {
+    spectator = pipeFactory(`{{ date | translocoDate:config }}`, {
+      hostProps: {
+        date,
+        config: { timeStyle: 'short' },
+      },
+      providers: [provideTranslocoLocaleConfigMock(LOCALE_CONFIG_MOCK)],
+    });
+    const [, { dateStyle, timeStyle }] = getIntlCallArgs(intlSpy);
+    expect(dateStyle).toEqual('medium');
+    expect(timeStyle).toEqual('short');
+  });
+
   describe('None date values', () => {
     it(`GIVEN null value
         WHEN transforming to date


### PR DESCRIPTION
TranslocoDatePipe spread the global `date` config over the pipe params, so a global `dateStyle` / `timeStyle` combined with params like `year` or `month` produced a mix that `Intl.DateTimeFormat` rejects with "Invalid option". The merge now drops `dateStyle` / `timeStyle` when the params use explicit component options, and vice versa; non-conflicting keys such as `timeZone` are still merged.

Closes #496

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date formatting when combining default and explicitly provided options.
  * Prevented conflicting date style and component settings from causing formatting errors.
  * Preserved compatible options, such as time zone preferences.

* **Tests**
  * Added coverage for option precedence, conflict handling, and retention of compatible settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->