### PR TITLE
fix(transloco): stop recursive scope loads when the fallback is cached

### DIFF
--- a/libs/transloco/src/lib/tests/service/fallbacks.spec.ts
+++ b/libs/transloco/src/lib/tests/service/fallbacks.spec.ts
@@ -174,6 +174,43 @@ describe('Multiple fallbacks', () => {
       expect(service.getActiveLang()).toEqual('en');
     }));
 
+    it(`GIVEN a scope that fails through a multi-lang fallback chain to a cached lang
+        WHEN it bails out
+        THEN the whole scoped chain is cleared from failedLangs (#647)`, fakeAsync(() => {
+      const scopeLoader = class implements TranslocoLoader {
+        getTranslation(lang: string) {
+          return timer(1000).pipe(
+            map(() => {
+              if (lang.startsWith('admin/')) {
+                throw new Error('error');
+              }
+              return mockLangs[lang];
+            }),
+          );
+        }
+      };
+
+      const service = createService(
+        { prodMode: true, fallbackLang: ['es', 'it'], failedRetries: 0 },
+        { loader: scopeLoader },
+      );
+
+      // cache the last fallback lang so the scoped chain short-circuits on it
+      service.load('it').subscribe();
+      runLoader(1);
+
+      // admin/en -> admin/es both 404 -> 'it' is cached -> bail out
+      service.selectTranslation('admin').subscribe();
+      runLoader(5);
+
+      expect((service as any).failedLangs.size).toEqual(0);
+
+      // a later unrelated success must not see wasFailure and flip the lang
+      service.load('es').subscribe();
+      runLoader(1);
+      expect(service.getActiveLang()).toEqual('en');
+    }));
+
     it(`GIVEN a scoped lang that fails to load AND all fallbacks fail
     THEN the error should contain a scope misspelling hint`, fakeAsync(() => {
       const service = createService(

--- a/libs/transloco/src/lib/tests/service/fallbacks.spec.ts
+++ b/libs/transloco/src/lib/tests/service/fallbacks.spec.ts
@@ -134,6 +134,46 @@ describe('Multiple fallbacks', () => {
       expect(service.load).toHaveBeenCalledTimes(2);
     }));
 
+    it(`GIVEN a scoped lang that fails while its fallback lang is already loaded
+        WHEN a consumer keeps re-subscribing through langChanges$
+        THEN the scope is not requested recursively (#647)`, fakeAsync(() => {
+      const scopeLoader = class implements TranslocoLoader {
+        getTranslation(lang: string) {
+          return timer(1000).pipe(
+            map(() => {
+              if (lang.startsWith('admin/')) {
+                throw new Error('error');
+              }
+              return mockLangs[lang];
+            }),
+          );
+        }
+      };
+
+      const service = createService(
+        { prodMode: true, fallbackLang: 'es', failedRetries: 0 },
+        { loader: scopeLoader },
+      );
+
+      // 'es' (the fallback) loads fine and gets cached
+      service.load('es').subscribe();
+      runLoader(1);
+
+      const getTranslation = vi.spyOn(
+        (service as any).loader as TranslocoLoader,
+        'getTranslation',
+      );
+
+      service.selectTranslation('admin').subscribe();
+      runLoader(20);
+
+      const scopeRequests = getTranslation.mock.calls.filter(([lang]) =>
+        (lang as string).startsWith('admin/'),
+      ).length;
+      expect(scopeRequests).toBeLessThanOrEqual(1);
+      expect(service.getActiveLang()).toEqual('en');
+    }));
+
     it(`GIVEN a scoped lang that fails to load AND all fallbacks fail
     THEN the error should contain a scope misspelling hint`, fakeAsync(() => {
       const service = createService(

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -840,12 +840,24 @@ export class TranslocoService {
     }
 
     const splitted = lang.split('/');
+    const isScoped = splitted.length > 1;
     const fallbacks = loadOptions.fallbackLangs;
     const nextLang = fallbacks![loadOptions.failedCounter!];
     this.failedLangs.add(lang);
 
     // This handles the case where a loaded fallback language is requested again
     if (this.cache.has(nextLang)) {
+      if (isScoped) {
+        // Bailing out here breaks an infinite load loop (#647). Example: `en` is
+        // the active, already-cached lang and `admin/en.json` 404s. Without this
+        // guard, handleSuccess('en') runs, evicts `admin/en` from the cache and
+        // emits `wasFailure` -> the events$ subscription calls setActiveLang('en')
+        // -> langChanges$ fires -> every directive re-subscribes -> `admin/en` is
+        // no longer cached -> it re-fetches -> 404 -> repeat forever. So for a
+        // scope, keep the cache entry and leave the active language alone.
+        this.failedLangs.delete(lang);
+        return EMPTY;
+      }
       this.handleSuccess(nextLang, this.getTranslation(nextLang));
       return EMPTY;
     }

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -855,7 +855,16 @@ export class TranslocoService {
         // -> langChanges$ fires -> every directive re-subscribes -> `admin/en` is
         // no longer cached -> it re-fetches -> 404 -> repeat forever. So for a
         // scope, keep the cache entry and leave the active language alone.
-        this.failedLangs.delete(lang);
+        //
+        // Drop the whole scoped fallback chain (`admin/en`, `admin/es`, ...), not
+        // just the current path - a leftover entry would make the next unrelated
+        // handleSuccess report `wasFailure`, evict that path and flip the lang.
+        const scopePrefix = `${splitted.slice(0, -1).join('/')}/`;
+        this.failedLangs.forEach((failedLang) => {
+          if (failedLang.startsWith(scopePrefix)) {
+            this.failedLangs.delete(failedLang);
+          }
+        });
         return EMPTY;
       }
       this.handleSuccess(nextLang, this.getTranslation(nextLang));


### PR DESCRIPTION
When a scoped translation file fails and its fallback language is already in the cache, handleFailure took the recovery shortcut: handleSuccess evicted the scope's own cache entry and emitted translationLoadSuccess with wasFailure, which flips the active language and makes every directive re-subscribe and re-fetch the still-missing scope - forever.

For a scoped path in that branch, bail out without evicting the cache or touching the active language.

Closes #647

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repeated reloads when a scoped language fails through a multi-language fallback chain with a cached fallback.
  * Cleared stale fallback failures to prevent later successful loads from incorrectly changing the active language.
  * Preserved the selected language and prevented unnecessary recursive loading.

* **Tests**
  * Added coverage for scoped fallback failures, cached fallbacks, and subsequent language loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->