### PR TITLE
chore: adapt create-pr skill for branch naming and PR rules

### DIFF
--- a/.claude/skills/create-branch-or-pr/SKILL.md
+++ b/.claude/skills/create-branch-or-pr/SKILL.md
@@ -39,16 +39,16 @@ These override any convenience shortcut — the developer reviews, then approves
 
 ### Prefix meaning & matching commit type
 
-| Branch prefix | Use for                                   | Commit/PR type |
-| -------------- | ------------------------------------------ | -------------- |
-| `feature`      | New functionality                           | `feat`         |
-| `bug`          | Bug fix                                     | `fix`          |
-| `hotfix`       | Urgent production fix                       | `fix`          |
-| `tech`         | Refactors, tooling, chores, deps            | `chore` (or `refactor`/`build`/`ci` if clearly a better fit) |
-| `docs`         | Documentation-only changes                  | `docs`         |
-| `ci`           | CI/workflow-only changes                    | `ci`           |
-| `release`      | Release preparation                         | `chore`        |
-| `e2e`          | Playwright e2e-only changes                 | `test`         |
+| Branch prefix | Use for                          | Commit/PR type                                               |
+| ------------- | -------------------------------- | ------------------------------------------------------------ |
+| `feature`     | New functionality                | `feat`                                                       |
+| `bug`         | Bug fix                          | `fix`                                                        |
+| `hotfix`      | Urgent production fix            | `fix`                                                        |
+| `tech`        | Refactors, tooling, chores, deps | `chore` (or `refactor`/`build`/`ci` if clearly a better fit) |
+| `docs`        | Documentation-only changes       | `docs`                                                       |
+| `ci`          | CI/workflow-only changes         | `ci`                                                         |
+| `release`     | Release preparation              | `chore`                                                      |
+| `e2e`         | Playwright e2e-only changes      | `test`                                                       |
 
 Prefer the most specific prefix: a documentation-only change belongs on `docs` (not
 `tech`), and a workflow-only change on `ci`. Because this repo squash-merges, the PR
@@ -69,15 +69,15 @@ names and commit-message convention):
 
 ### Examples
 
-| Branch                                                | PR/commit title                                                              |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| `bug/locale-drop-conflicting-date-options`              | `fix(locale): drop conflicting date options when merging the global config`   |
-| `feature/keys-manager-support-yaml-output`              | `feat(keys-manager): support yaml output`                                     |
-| `tech/persist-lang-upgrade-nx`                          | `chore(persist-lang): upgrade nx`                                             |
-| `tech/upgrade-nx` (root-level, no single package scope) | `chore: upgrade nx`                                                           |
-| `e2e/scoped-libs-stabilize-lazy-load-scenario`          | `test(scoped-libs): stabilize lazy load scenario`                             |
-| `docs/locale-document-date-format-options`              | `docs(locale): document date format options`                                 |
-| `ci/cache-playwright-browsers`                          | `ci: cache playwright browsers`                                              |
+| Branch                                                  | PR/commit title                                                             |
+| ------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `bug/locale-drop-conflicting-date-options`              | `fix(locale): drop conflicting date options when merging the global config` |
+| `feature/keys-manager-support-yaml-output`              | `feat(keys-manager): support yaml output`                                   |
+| `tech/persist-lang-upgrade-nx`                          | `chore(persist-lang): upgrade nx`                                           |
+| `tech/upgrade-nx` (root-level, no single package scope) | `chore: upgrade nx`                                                         |
+| `e2e/scoped-libs-stabilize-lazy-load-scenario`          | `test(scoped-libs): stabilize lazy load scenario`                           |
+| `docs/locale-document-date-format-options`              | `docs(locale): document date format options`                                |
+| `ci/cache-playwright-browsers`                          | `ci: cache playwright browsers`                                             |
 
 ## Procedure
 

--- a/.claude/skills/create-branch-or-pr/SKILL.md
+++ b/.claude/skills/create-branch-or-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: create-pr
+name: create-branch-or-pr
 description: "Name branches correctly and create a pull request for the current branch in the Transloco repo. Use when the user asks to 'create a branch', 'name my branch', 'create a PR', 'open a pull request', or 'submit a PR'. Enforces the branch-naming convention, derives a conventional-commit PR title (type(scope): description), fills in .github/pull_request_template.md, and auto-applies matching repo labels."
 ---
 

--- a/.claude/skills/create-branch-or-pr/SKILL.md
+++ b/.claude/skills/create-branch-or-pr/SKILL.md
@@ -61,11 +61,22 @@ this list.
 ### Scopes
 
 Scope is the package name, without the `transloco-` prefix (matches `libs/` folder
-names and commit-message convention):
+names and commit-message convention).
 
-`transloco` (core, no suffix), `locale`, `messageformat`, `optimize`, `persist-lang`,
-`persist-translations`, `preload-langs`, `scoped-libs`, `keys-manager`, `schematics`,
-`utils`, `validator`
+`changelog.config.js` is the source of truth — it's the same list `npm run commit`
+offers. Read it at runtime rather than trusting the snapshot below:
+
+```bash
+node -p "require('./changelog.config.js').scopes.filter(Boolean).join(', ')"
+```
+
+At the time of writing that yields: `transloco` (core, no suffix), `keys-manager`,
+`locale`, `messageformat`, `optimize`, `persist-lang`, `persist-translations`,
+`preload-langs`, `scoped-libs`, `utils`, `validator`, `schematics`. If the command
+output differs, the command wins.
+
+Note the empty string in that array is the "no scope" option — filter it out, and omit
+the scope entirely for changes that aren't tied to one package.
 
 ### Examples
 
@@ -118,10 +129,10 @@ names and commit-message convention):
 3. **Determine `<scope>`**
 
    - Prefer the scope encoded in the branch name: after `<prefix>/`, match the
-     longest known scope (see **Scopes** above) that forms a prefix of the
-     remainder followed by a `-` (e.g. `persist-lang-upgrade-nx` → scope
-     `persist-lang`, description `upgrade-nx`) — this correctly handles
-     hyphenated scope names.
+     longest known scope (resolved from `changelog.config.js`, see **Scopes** above)
+     that forms a prefix of the remainder followed by a `-` (e.g.
+     `persist-lang-upgrade-nx` → scope `persist-lang`, description `upgrade-nx`) —
+     this correctly handles hyphenated scope names.
    - Otherwise, if no known scope matches as a prefix, infer it from the changed
      files vs. the base branch
      (`git diff --name-only master...HEAD`): `libs/transloco-<scope>/` maps to

--- a/.claude/skills/create-branch-or-pr/SKILL.md
+++ b/.claude/skills/create-branch-or-pr/SKILL.md
@@ -32,7 +32,7 @@ These override any convenience shortcut — the developer reviews, then approves
 <prefix>/<kebab-case-description>            (no scope, for repo-wide changes)
 ```
 
-- `<prefix>`: one of `feature`, `tech`, `bug`, `release`, `hotfix`, `e2e`
+- `<prefix>`: one of `feature`, `tech`, `bug`, `release`, `hotfix`, `e2e`, `docs`, `ci`
 - `<scope>`: optional, a package/library scope (see **Scopes** below). Omit it for
   changes that aren't tied to one package (root config, CI, docs, monorepo tooling).
 - `<kebab-case-description>`: short, human-readable summary of the change.
@@ -45,8 +45,14 @@ These override any convenience shortcut — the developer reviews, then approves
 | `bug`          | Bug fix                                     | `fix`          |
 | `hotfix`       | Urgent production fix                       | `fix`          |
 | `tech`         | Refactors, tooling, chores, deps            | `chore` (or `refactor`/`build`/`ci` if clearly a better fit) |
+| `docs`         | Documentation-only changes                  | `docs`         |
+| `ci`           | CI/workflow-only changes                    | `ci`           |
 | `release`      | Release preparation                         | `chore`        |
 | `e2e`          | Playwright e2e-only changes                 | `test`         |
+
+Prefer the most specific prefix: a documentation-only change belongs on `docs` (not
+`tech`), and a workflow-only change on `ci`. Because this repo squash-merges, the PR
+title becomes the changelog entry — filing docs work as `chore` hides it there.
 
 `commitlint.config.js` only allows these commit types: `build`, `chore`, `ci`, `docs`,
 `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`, `plugin`. Always pick from
@@ -70,6 +76,8 @@ names and commit-message convention):
 | `tech/persist-lang-upgrade-nx`                          | `chore(persist-lang): upgrade nx`                                             |
 | `tech/upgrade-nx` (root-level, no single package scope) | `chore: upgrade nx`                                                           |
 | `e2e/scoped-libs-stabilize-lazy-load-scenario`          | `test(scoped-libs): stabilize lazy load scenario`                             |
+| `docs/locale-document-date-format-options`              | `docs(locale): document date format options`                                 |
+| `ci/cache-playwright-browsers`                          | `ci: cache playwright browsers`                                              |
 
 ## Procedure
 
@@ -140,6 +148,7 @@ names and commit-message convention):
 
    - Check the correct **PR Type** box(es) based on the branch prefix (`bug`/`hotfix`
      → Bugfix, `feature` → Feature, `tech` → Refactoring/Build/CI as fitting,
+     `docs` → Documentation content changes, `ci` → Build related changes/CI,
      `release` → Other, `e2e` → Other/Refactoring).
    - Fill in **What is the current behavior?** / **What is the new behavior?** from the
      actual diff, and the **Issue Number** line from step 5.
@@ -166,8 +175,9 @@ names and commit-message convention):
    - Apply the package label matching `<scope>`, if one exists (e.g. `locale`,
      `keys-manager`, `persist-lang`) — these are named exactly after the scope.
    - Apply a type label only when one clearly matches: `bug`/`hotfix` → `bug`,
-     `feature` → `enhancement`. There's no dedicated label for `tech`, `release`,
-     or `e2e` — skip a type label rather than guessing one for those prefixes.
+     `feature` → `enhancement`, `docs` → `documentation`. There's no dedicated label
+     for `tech`, `ci`, `release`, or `e2e` — skip a type label rather than guessing
+     one for those prefixes.
    - Optionally add one `area: <topic>` label, but only when the change content
      clearly matches that label's description with high confidence (e.g. a change to
      the transpiler → `area: transpiler`). Skip it if uncertain.

--- a/.claude/skills/create-branch-or-pr/SKILL.md
+++ b/.claude/skills/create-branch-or-pr/SKILL.md
@@ -80,15 +80,16 @@ the scope entirely for changes that aren't tied to one package.
 
 ### Examples
 
-| Branch                                                  | PR/commit title                                                             |
-| ------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `bug/locale-drop-conflicting-date-options`              | `fix(locale): drop conflicting date options when merging the global config` |
-| `feature/keys-manager-support-yaml-output`              | `feat(keys-manager): support yaml output`                                   |
-| `tech/persist-lang-upgrade-nx`                          | `chore(persist-lang): upgrade nx`                                           |
-| `tech/upgrade-nx` (root-level, no single package scope) | `chore: upgrade nx`                                                         |
-| `e2e/scoped-libs-stabilize-lazy-load-scenario`          | `test(scoped-libs): stabilize lazy load scenario`                           |
-| `docs/locale-document-date-format-options`              | `docs(locale): document date format options`                                |
-| `ci/cache-playwright-browsers`                          | `ci: cache playwright browsers`                                             |
+| Branch                                                              | PR/commit title                                                             |
+| ------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `bug/locale-drop-conflicting-date-options`                          | `fix(locale): drop conflicting date options when merging the global config` |
+| `feature/keys-manager-support-yaml-output`                          | `feat(keys-manager): support yaml output`                                   |
+| `tech/persist-lang-upgrade-nx`                                      | `chore(persist-lang): upgrade nx`                                           |
+| `tech/upgrade-nx` (root-level, no single package scope)             | `chore: upgrade nx`                                                         |
+| `tech/optimize-build-times` (touches no `libs/transloco-optimize/`) | `chore: optimize build times` — **not** `chore(optimize):`                  |
+| `e2e/scoped-libs-stabilize-lazy-load-scenario`                      | `test(scoped-libs): stabilize lazy load scenario`                           |
+| `docs/locale-document-date-format-options`                          | `docs(locale): document date format options`                                |
+| `ci/cache-playwright-browsers`                                      | `ci: cache playwright browsers`                                             |
 
 ## Procedure
 
@@ -126,17 +127,24 @@ the scope entirely for changes that aren't tied to one package.
 2. **Determine `<type>`** from the current branch's `<prefix>` using the mapping
    table above.
 
-3. **Determine `<scope>`**
+3. **Determine `<scope>`** — always derive it from the changed files; the branch name
+   is only a hint that must be corroborated.
 
-   - Prefer the scope encoded in the branch name: after `<prefix>/`, match the
+   - Get the changed files first: `git diff --name-only master...HEAD`. Map them to
+     scopes: `libs/transloco-<scope>/` → `<scope>`; `libs/transloco/` → `transloco`.
+   - Read the candidate scope from the branch name: after `<prefix>/`, match the
      longest known scope (resolved from `changelog.config.js`, see **Scopes** above)
      that forms a prefix of the remainder followed by a `-` (e.g.
      `persist-lang-upgrade-nx` → scope `persist-lang`, description `upgrade-nx`) —
      this correctly handles hyphenated scope names.
-   - Otherwise, if no known scope matches as a prefix, infer it from the changed
-     files vs. the base branch
-     (`git diff --name-only master...HEAD`): `libs/transloco-<scope>/` maps to
-     `<scope>`; `libs/transloco/` maps to `transloco`.
+   - Use that candidate **only if the changed files actually touch that package.**
+     A branch can be named for its _intent_ rather than its package, and several
+     scope names double as ordinary English words: `tech/optimize-build-times`
+     matches `optimize` and `tech/utils-cleanup` matches `utils`, yet neither may
+     touch `libs/transloco-optimize/` or `libs/transloco-utils/`. Labelling those
+     `chore(optimize):` / `chore(utils):` is wrong and misleads the changelog.
+   - If the branch-name candidate isn't corroborated (or there is none), fall back to
+     the file-based scope.
    - If changes span multiple packages, or touch only root/shared files, omit the
      scope entirely — don't force one.
 

--- a/.claude/skills/create-branch-or-pr/SKILL.md
+++ b/.claude/skills/create-branch-or-pr/SKILL.md
@@ -25,6 +25,12 @@ These override any convenience shortcut — the developer reviews, then approves
 - If the user only asked for part of the flow (e.g. "commit this"), stop there —
   don't continue into pushing or PR creation on your own.
 
+Wherever this skill says "ask the developer", use whatever interactive-question
+mechanism your agent provides, and wait for the answer instead of guessing. The
+mechanism is agent-specific, so no tool name is hardcoded here — this file lives under
+`.claude/`, but other assistants (e.g. GitHub Copilot CLI) discover skills from that
+directory too.
+
 ## Branch Naming Convention
 
 ```text
@@ -174,8 +180,8 @@ the scope entirely for changes that aren't tied to one package.
 
    - Look for an issue number in the branch name or recent commits.
    - If none is obvious, use `gh issue list --search "<key terms>"` to check for a
-     matching open issue. If genuinely unsure, ask the user with `ask_user` whether
-     the PR closes a specific issue number; don't fabricate one.
+     matching open issue. If genuinely unsure, ask the developer whether the PR
+     closes a specific issue number; don't fabricate one.
    - If an issue is found, note it as `Closes #<number>`; otherwise leave the
      template's "Issue Number: N/A" as-is.
 

--- a/.claude/skills/create-branch-or-pr/SKILL.md
+++ b/.claude/skills/create-branch-or-pr/SKILL.md
@@ -102,7 +102,23 @@ the scope entirely for changes that aren't tied to one package.
 
 ### 2. Creating a PR
 
-1. **Commit any pending work first**
+1. **Resolve the base branch first** — never assume `master`.
+
+   - Default: the repo's default branch, read at runtime rather than hardcoded:
+     `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`.
+   - Exception: `CONTRIBUTING.md` routes GitBook documentation contributions to the
+     `gitbook-docs` branch. If the change edits that documentation content, the base
+     is `gitbook-docs`, not the default branch. (Repo-level docs that live on the
+     default branch — `README.md`, `CONTRIBUTING.md`, `docs/` — still target the
+     default branch.) If it's ambiguous, ask the user rather than guessing.
+   - Make sure the remote ref is current before diffing — `git fetch origin <base>` —
+     and always diff against `origin/<base>`, never the local ref. A local `master`
+     can be stale or entirely absent in a fresh clone or a fork, which silently
+     yields a wrong changed-file list with no error.
+   - Use this resolved `<base>` everywhere below: `origin/<base>...HEAD` for diffs and
+     `--base <base>` when creating the PR.
+
+2. **Commit any pending work first**
 
    - Check `git status --porcelain`. If there are staged/unstaged/untracked changes,
      show the list of affected files to the user and get explicit confirmation
@@ -124,14 +140,15 @@ the scope entirely for changes that aren't tied to one package.
      Never chain `git add` and `git commit` in one command so the developer always
      has a chance to review the staged diff first.
 
-2. **Determine `<type>`** from the current branch's `<prefix>` using the mapping
+3. **Determine `<type>`** from the current branch's `<prefix>` using the mapping
    table above.
 
-3. **Determine `<scope>`** — always derive it from the changed files; the branch name
+4. **Determine `<scope>`** — always derive it from the changed files; the branch name
    is only a hint that must be corroborated.
 
-   - Get the changed files first: `git diff --name-only master...HEAD`. Map them to
-     scopes: `libs/transloco-<scope>/` → `<scope>`; `libs/transloco/` → `transloco`.
+   - Get the changed files first: `git diff --name-only origin/<base>...HEAD`. Map
+     them to scopes: `libs/transloco-<scope>/` → `<scope>`; `libs/transloco/` →
+     `transloco`.
    - Read the candidate scope from the branch name: after `<prefix>/`, match the
      longest known scope (resolved from `changelog.config.js`, see **Scopes** above)
      that forms a prefix of the remainder followed by a `-` (e.g.
@@ -148,11 +165,11 @@ the scope entirely for changes that aren't tied to one package.
    - If changes span multiple packages, or touch only root/shared files, omit the
      scope entirely — don't force one.
 
-4. **Build the PR title**: `<type>(<scope>): <description>`, or `<type>: <description>`
+5. **Build the PR title**: `<type>(<scope>): <description>`, or `<type>: <description>`
    with no scope. Keep it lowercase after the colon, imperative mood, no trailing period
    (e.g. `fix(locale): drop conflicting date options when merging the global config`).
 
-5. **Check for a related issue** (this repo has no ticket/DevOps system — issues are
+6. **Check for a related issue** (this repo has no ticket/DevOps system — issues are
    optional and opportunistic):
 
    - Look for an issue number in the branch name or recent commits.
@@ -162,7 +179,7 @@ the scope entirely for changes that aren't tied to one package.
    - If an issue is found, note it as `Closes #<number>`; otherwise leave the
      template's "Issue Number: N/A" as-is.
 
-6. **Fill in `.github/pull_request_template.md`** as the PR body — don't skip or
+7. **Fill in `.github/pull_request_template.md`** as the PR body — don't skip or
    replace it:
 
    - Check the correct **PR Type** box(es) based on the branch prefix (`bug`/`hotfix`
@@ -170,24 +187,25 @@ the scope entirely for changes that aren't tied to one package.
      `docs` → Documentation content changes, `ci` → Build related changes/CI,
      `release` → Other, `e2e` → Other/Refactoring).
    - Fill in **What is the current behavior?** / **What is the new behavior?** from the
-     actual diff, and the **Issue Number** line from step 5.
+     actual diff, and the **Issue Number** line from step 6.
    - Check the **Does this PR introduce a breaking change?** box truthfully.
    - Leave the checklist items as checkboxes for the author/reviewer to verify (don't
      pre-check tests/docs boxes unless you actually added them in this change).
 
-7. **Push and create the PR**:
+8. **Push and create the PR**:
 
-   - Show the user the final PR title and body, and get explicit approval before
-     pushing. Never push or open a PR automatically as a side effect of another
-     request — the developer decides when work leaves their machine.
+   - Show the user the final PR title, body and resolved base branch, and get explicit
+     approval before pushing. Never push or open a PR automatically as a side effect
+     of another request — the developer decides when work leaves their machine.
    - Push the branch: `git push -u origin <branch>`.
    - Never use `--force`/`--force-with-lease` unless the user explicitly asks for it.
-   - Create the PR against `master` with the built title and the filled-in template
-     as the body (`gh pr create --title "..." --body-file <file> --base master`).
+   - Create the PR against the `<base>` resolved in step 1, with the built title and
+     the filled-in template as the body:
+     `gh pr create --title "..." --body-file <file> --base <base>`.
    - Default to a normal (non-draft) PR; only pass `--draft` if the user explicitly
      asked for a draft.
 
-8. **Apply labels**
+9. **Apply labels**
 
    - Fetch current labels and descriptions with `gh label list` (don't hardcode —
      labels and descriptions can change over time).

--- a/.claude/skills/create-branch-or-pr/SKILL.md
+++ b/.claude/skills/create-branch-or-pr/SKILL.md
@@ -13,6 +13,18 @@ description: "Name branches correctly and create a pull request for the current 
 This skill enforces the branch-naming convention and the commit/PR rules from
 `CONTRIBUTING.md` and `commitlint.config.js`.
 
+## Safety Rules (apply to every step)
+
+These override any convenience shortcut — the developer reviews, then approves:
+
+- **Never stage, commit, push, or open a PR without explicit user approval.** Each of
+  these is a separate confirmation; approving a commit is not approval to push.
+- Never run `git add -A`/`git add .`; stage explicit paths the user agreed to.
+- Never chain staging and committing in a single command.
+- Never amend, rebase, reset, or force-push unless the user explicitly asks.
+- If the user only asked for part of the flow (e.g. "commit this"), stop there —
+  don't continue into pushing or PR creation on your own.
+
 ## Branch Naming Convention
 
 ```text
@@ -82,10 +94,15 @@ names and commit-message convention):
      instead of asking again.
    - Once confirmed, stage only the agreed-upon files (prefer explicit paths over
      `git add -A`) and proceed.
-   - Determine `<type>` and `<scope>` (see below), then commit with:
+   - Determine `<type>` and `<scope>` (see below), then build the message:
      `<type>(<scope>): <description>` — generated from the actual diff content, not a
      generic message. Omit `(<scope>)` if no single package scope applies.
    - Follow `CONTRIBUTING.md`: this is the same format produced by `npm run commit`.
+   - **Never commit without explicit approval.** Show the user the staged file list
+     and the proposed commit message, and wait for an explicit "yes" before running
+     `git commit`. If the user asks for a different message, use theirs verbatim.
+     Never chain `git add` and `git commit` in one command so the developer always
+     has a chance to review the staged diff first.
 
 2. **Determine `<type>`** from the current branch's `<prefix>` using the mapping
    table above.
@@ -132,7 +149,11 @@ names and commit-message convention):
 
 7. **Push and create the PR**:
 
+   - Show the user the final PR title and body, and get explicit approval before
+     pushing. Never push or open a PR automatically as a side effect of another
+     request — the developer decides when work leaves their machine.
    - Push the branch: `git push -u origin <branch>`.
+   - Never use `--force`/`--force-with-lease` unless the user explicitly asks for it.
    - Create the PR against `master` with the built title and the filled-in template
      as the body (`gh pr create --title "..." --body-file <file> --base master`).
    - Default to a normal (non-draft) PR; only pass `--draft` if the user explicitly

--- a/.claude/skills/create-branch-or-pr/SKILL.md
+++ b/.claude/skills/create-branch-or-pr/SKILL.md
@@ -131,11 +131,13 @@ the scope entirely for changes that aren't tied to one package.
      before staging anything — never run `git add -A` (or stage any file)
      automatically. This avoids committing files the user hasn't reviewed
      (including accidentally sensitive/local files).
-   - If the user has already given explicit instructions on what/how to stage or
-     commit (e.g. specific files, or "stage everything"), follow those instructions
-     instead of asking again.
-   - Once confirmed, stage only the agreed-upon files (prefer explicit paths over
-     `git add -A`) and proceed.
+   - Broad wording (e.g. "stage everything") is not itself permission to run
+     `git add -A` or `git add .` — it still requires enumerating the candidate
+     files from `git status --porcelain`, displaying the exact paths to the user,
+     and getting explicit approval before staging. Only skip re-asking when the
+     user has already named the specific files/paths to stage.
+   - Once confirmed, stage only the agreed-upon files by explicit path (never
+     `git add -A` / `git add .`) and proceed.
    - Determine `<type>` and `<scope>` (see below), then build the message:
      `<type>(<scope>): <description>` — generated from the actual diff content, not a
      generic message. Omit `(<scope>)` if no single package scope applies.
@@ -178,12 +180,15 @@ the scope entirely for changes that aren't tied to one package.
 6. **Check for a related issue** (this repo has no ticket/DevOps system — issues are
    optional and opportunistic):
 
-   - Look for an issue number in the branch name or recent commits.
-   - If none is obvious, use `gh issue list --search "<key terms>"` to check for a
-     matching open issue. If genuinely unsure, ask the developer whether the PR
-     closes a specific issue number; don't fabricate one.
-   - If an issue is found, note it as `Closes #<number>`; otherwise leave the
-     template's "Issue Number: N/A" as-is.
+   - Look for an issue number in the branch name or recent commits, and use
+     `gh issue list --search "<key terms>"` to check for a matching open issue.
+     Treat all of these (branch name, commit references, keyword search results)
+     as candidates only, never as confirmed.
+   - Ask the developer to explicitly confirm the exact issue number before adding
+     `Closes #<number>` — don't add it based on a candidate alone, and don't
+     fabricate one.
+   - If confirmation isn't given (or no candidate exists), leave the template's
+     "Issue Number: N/A" as-is; don't add a closing reference.
 
 7. **Fill in `.github/pull_request_template.md`** as the PR body — don't skip or
    replace it:
@@ -205,6 +210,9 @@ the scope entirely for changes that aren't tied to one package.
      of another request — the developer decides when work leaves their machine.
    - Push the branch: `git push -u origin <branch>`.
    - Never use `--force`/`--force-with-lease` unless the user explicitly asks for it.
+   - After the push, display the final PR title, body, and resolved base branch again
+     and wait for a separate, explicit approval before running `gh pr create` — the
+     push approval does not double as approval to open the PR.
    - Create the PR against the `<base>` resolved in step 1, with the built title and
      the filled-in template as the body:
      `gh pr create --title "..." --body-file <file> --base <base>`.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -73,7 +73,15 @@ names and commit-message convention):
 1. **Commit any pending work first**
 
    - Check `git status --porcelain`. If there are staged/unstaged/untracked changes,
-     stage everything (`git add -A`).
+     show the list of affected files to the user and get explicit confirmation
+     before staging anything — never run `git add -A` (or stage any file)
+     automatically. This avoids committing files the user hasn't reviewed
+     (including accidentally sensitive/local files).
+   - If the user has already given explicit instructions on what/how to stage or
+     commit (e.g. specific files, or "stage everything"), follow those instructions
+     instead of asking again.
+   - Once confirmed, stage only the agreed-upon files (prefer explicit paths over
+     `git add -A`) and proceed.
    - Determine `<type>` and `<scope>` (see below), then commit with:
      `<type>(<scope>): <description>` — generated from the actual diff content, not a
      generic message. Omit `(<scope>)` if no single package scope applies.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: create-pr
+description: "Name branches correctly and create a pull request for the current branch in the Transloco repo. Use when the user asks to 'create a branch', 'name my branch', 'create a PR', 'open a pull request', or 'submit a PR'. Enforces the branch-naming convention, derives a conventional-commit PR title (type(scope): description), fills in .github/pull_request_template.md, and auto-applies matching repo labels."
+---
+
+# Name Branches & Create PRs (Transloco)
+
+## When to Use
+
+- The user wants help naming a new branch before starting work.
+- The user asks to create/open/submit a pull request for the current branch.
+
+This skill enforces the branch-naming convention and the commit/PR rules from
+`CONTRIBUTING.md` and `commitlint.config.js`.
+
+## Branch Naming Convention
+
+```
+<prefix>/<scope>-<kebab-case-description>
+<prefix>/<kebab-case-description>            (no scope, for repo-wide changes)
+```
+
+- `<prefix>`: one of `feature`, `tech`, `bug`, `release`, `hotfix`, `e2e`
+- `<scope>`: optional, a package/library scope (see **Scopes** below). Omit it for
+  changes that aren't tied to one package (root config, CI, docs, monorepo tooling).
+- `<kebab-case-description>`: short, human-readable summary of the change.
+
+### Prefix meaning & matching commit type
+
+| Branch prefix | Use for                                   | Commit/PR type |
+| -------------- | ------------------------------------------ | -------------- |
+| `feature`      | New functionality                           | `feat`         |
+| `bug`          | Bug fix                                     | `fix`          |
+| `hotfix`       | Urgent production fix                       | `fix`          |
+| `tech`         | Refactors, tooling, chores, deps            | `chore` (or `refactor`/`build`/`ci` if clearly a better fit) |
+| `release`      | Release preparation                         | `chore`        |
+| `e2e`          | Playwright e2e-only changes                 | `test`         |
+
+`commitlint.config.js` only allows these commit types: `build`, `chore`, `ci`, `docs`,
+`feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`, `plugin`. Always pick from
+this list.
+
+### Scopes
+
+Scope is the package name, without the `transloco-` prefix (matches `libs/` folder
+names and commit-message convention):
+
+`transloco` (core, no suffix), `locale`, `messageformat`, `optimize`, `persist-lang`,
+`persist-translations`, `preload-langs`, `scoped-libs`, `keys-manager`, `schematics`,
+`utils`, `validator`
+
+### Examples
+
+| Branch                                                | PR/commit title                                                              |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| `bug/locale-drop-conflicting-date-options`              | `fix(locale): drop conflicting date options when merging the global config`   |
+| `feature/keys-manager-support-yaml-output`              | `feat(keys-manager): support yaml output`                                     |
+| `tech/persist-lang-upgrade-nx`                          | `chore(persist-lang): upgrade nx`                                             |
+| `tech/upgrade-nx` (root-level, no single package scope) | `chore: upgrade nx`                                                           |
+| `e2e/scoped-libs-stabilize-lazy-load-scenario`          | `test(scoped-libs): stabilize lazy load scenario`                             |
+
+## Procedure
+
+### 1. Naming a new branch (if that's what's being asked)
+
+- Ask (or infer from context) what the change is about, pick the right `<prefix>`
+  from the table above, determine the `<scope>` (or omit it), and propose the
+  `<prefix>/<scope>-<description>` branch name. Create it with
+  `git checkout -b <name>` once confirmed.
+
+### 2. Creating a PR
+
+1. **Commit any pending work first**
+
+   - Check `git status --porcelain`. If there are staged/unstaged/untracked changes,
+     stage everything (`git add -A`).
+   - Determine `<type>` and `<scope>` (see below), then commit with:
+     `<type>(<scope>): <description>` — generated from the actual diff content, not a
+     generic message. Omit `(<scope>)` if no single package scope applies.
+   - Follow `CONTRIBUTING.md`: this is the same format produced by `npm run commit`.
+
+2. **Determine `<type>`** from the current branch's `<prefix>` using the mapping
+   table above.
+
+3. **Determine `<scope>`**
+
+   - Prefer the scope encoded in the branch name (the segment right after
+     `<prefix>/`), if it matches one of the known scopes.
+   - Otherwise, infer it from the changed files vs. the base branch
+     (`git diff --name-only master...HEAD`): `libs/transloco-<scope>/` maps to
+     `<scope>`; `libs/transloco/` maps to `transloco`.
+   - If changes span multiple packages, or touch only root/shared files, omit the
+     scope entirely — don't force one.
+
+4. **Build the PR title**: `<type>(<scope>): <description>`, or `<type>: <description>`
+   with no scope. Keep it lowercase after the colon, imperative mood, no trailing period
+   (e.g. `fix(locale): drop conflicting date options when merging the global config`).
+
+5. **Check for a related issue** (this repo has no ticket/DevOps system — issues are
+   optional and opportunistic):
+
+   - Look for an issue number in the branch name or recent commits.
+   - If none is obvious, use `gh issue list --search "<key terms>"` to check for a
+     matching open issue. If genuinely unsure, ask the user with `ask_user` whether
+     the PR closes a specific issue number; don't fabricate one.
+   - If an issue is found, note it as `Closes #<number>`; otherwise leave the
+     template's "Issue Number: N/A" as-is.
+
+6. **Fill in `.github/pull_request_template.md`** as the PR body — don't skip or
+   replace it:
+
+   - Check the correct **PR Type** box(es) based on the branch prefix (`bug`/`hotfix`
+     → Bugfix, `feature` → Feature, `tech` → Refactoring/Build/CI as fitting,
+     `release` → Other, `e2e` → Other/Refactoring).
+   - Fill in **What is the current behavior?** / **What is the new behavior?** from the
+     actual diff, and the **Issue Number** line from step 5.
+   - Check the **Does this PR introduce a breaking change?** box truthfully.
+   - Leave the checklist items as checkboxes for the author/reviewer to verify (don't
+     pre-check tests/docs boxes unless you actually added them in this change).
+
+7. **Push and create the PR**:
+
+   - Push the branch: `git push -u origin <branch>`.
+   - Create the PR against `master` with the built title and the filled-in template
+     as the body (`gh pr create --title "..." --body-file <file> --base master`).
+   - Default to a normal (non-draft) PR; only pass `--draft` if the user explicitly
+     asked for a draft.
+
+8. **Apply labels**
+
+   - Fetch current labels and descriptions with `gh label list` (don't hardcode —
+     labels and descriptions can change over time).
+   - Apply the package label matching `<scope>`, if one exists (e.g. `locale`,
+     `keys-manager`, `persist-lang`) — these are named exactly after the scope.
+   - Apply a type label only when one clearly matches: `bug`/`hotfix` → `bug`,
+     `feature` → `enhancement`. There's no dedicated label for `tech`, `release`,
+     `e2e`, or `hotfix` — skip a type label rather than guessing one.
+   - Optionally add one `area: <topic>` label, but only when the change content
+     clearly matches that label's description with high confidence (e.g. a change to
+     the transpiler → `area: transpiler`). Skip it if uncertain.
+   - Apply labels with `gh pr edit <number> --add-label "<label1>,<label2>"`.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -15,7 +15,7 @@ This skill enforces the branch-naming convention and the commit/PR rules from
 
 ## Branch Naming Convention
 
-```
+```text
 <prefix>/<scope>-<kebab-case-description>
 <prefix>/<kebab-case-description>            (no scope, for repo-wide changes)
 ```
@@ -84,9 +84,13 @@ names and commit-message convention):
 
 3. **Determine `<scope>`**
 
-   - Prefer the scope encoded in the branch name (the segment right after
-     `<prefix>/`), if it matches one of the known scopes.
-   - Otherwise, infer it from the changed files vs. the base branch
+   - Prefer the scope encoded in the branch name: after `<prefix>/`, match the
+     longest known scope (see **Scopes** above) that forms a prefix of the
+     remainder followed by a `-` (e.g. `persist-lang-upgrade-nx` → scope
+     `persist-lang`, description `upgrade-nx`) — this correctly handles
+     hyphenated scope names.
+   - Otherwise, if no known scope matches as a prefix, infer it from the changed
+     files vs. the base branch
      (`git diff --name-only master...HEAD`): `libs/transloco-<scope>/` maps to
      `<scope>`; `libs/transloco/` maps to `transloco`.
    - If changes span multiple packages, or touch only root/shared files, omit the
@@ -134,7 +138,7 @@ names and commit-message convention):
      `keys-manager`, `persist-lang`) — these are named exactly after the scope.
    - Apply a type label only when one clearly matches: `bug`/`hotfix` → `bug`,
      `feature` → `enhancement`. There's no dedicated label for `tech`, `release`,
-     `e2e`, or `hotfix` — skip a type label rather than guessing one.
+     or `e2e` — skip a type label rather than guessing one for those prefixes.
    - Optionally add one `area: <topic>` label, but only when the change content
      clearly matches that label's description with high confidence (e.g. a change to
      the transpiler → `area: transpiler`). Skip it if uncertain.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jsverse/transloco/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Adds/updates an internal AI agent skill (tooling, not shipped code)

## What is the current behavior?

This repo did not yet have an agent skill to help developers name branches correctly
and follow this project's coding and contribution rules when opening a PR.

Issue Number: N/A

## What is the new behavior?

Adds `.claude/skills/create-branch-or-pr/SKILL.md`, a skill that encodes Transloco's
own conventions rather than generic ones:

- Documents the branch naming convention (`<prefix>/<scope>-<description>`) using this
  repo's branch prefixes (`feature`, `tech`, `bug`, `release`, `hotfix`, `e2e`, `docs`,
  `ci`) mapped to valid commitlint types (`feat`, `fix`, `chore`, `test`, `docs`, `ci`).
- Resolves scopes at runtime from `changelog.config.js` — the same list `npm run commit`
  offers — instead of duplicating it.
- Produces conventional-commit style PR titles, e.g.
  `fix(locale): drop conflicting date options when merging the global config`.
- Optional GitHub issue linking, only when one clearly exists.
- Fills in the existing `.github/pull_request_template.md` instead of a custom body.
- Applies matching repo labels (package/scope labels, plus `bug`/`enhancement`/
  `documentation` where applicable) fetched live via `gh label list`.

### Safety

The skill never acts on the repo without the developer's approval: staging, committing,
pushing and opening the PR are each a separate confirmation. No `git add -A`, no
chaining `add` + `commit`, and no amend/rebase/reset/force-push unless explicitly asked.

### Review feedback addressed

- **`docs` / `ci` prefixes** — previously unreachable, so docs-only work was filed as
  `chore` and, because we squash-merge, shipped that way in the changelog. This also
  makes the `documentation` label reachable.
- **Scopes derived from config** — no more hardcoded snapshot drifting from
  `changelog.config.js`.
- **Scope inference corroborated by the diff** — `tech/optimize-build-times` no longer
  becomes `chore(optimize):` when it touches no `libs/transloco-optimize/` file.
- **Base branch resolved at runtime** — no hardcoded `master`. Honours the
  `gitbook-docs` route from `CONTRIBUTING.md`, and diffs against `origin/<base>` so a
  stale or missing local ref can't silently produce a wrong file list.
- **Agent-neutral prompts** — no assistant-specific tool name is hardcoded, since
  `.claude/skills/` is read by both Claude Code and GitHub Copilot CLI.
- **Formatting** — tables run through Prettier.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Internal tooling change only (agent skill definition) — no runtime code, build, or
public API is affected. `.claude/` is excluded from Prettier via `.prettierignore`, so
the file was formatted manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for creating consistently named branches and pull requests.
  - Documented commit type and scope conventions, runtime scope resolution, base-branch handling, issue-link confirmation, pull request templates, and labeling steps.
  - Added safety guidance requiring explicit approval before staging, committing, pushing, or opening pull requests.
  - Clarified the use of separate approval checkpoints throughout the pull request creation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->