### PR TITLE
feat(transloco): make translate() track activeLang in reactive contexts

### DIFF
--- a/libs/transloco/src/lib/tests/service/reactive-context.spec.ts
+++ b/libs/transloco/src/lib/tests/service/reactive-context.spec.ts
@@ -1,0 +1,52 @@
+import { computed } from '@angular/core';
+import { fakeAsync } from '@angular/core/testing';
+
+import { createService, mockLangs } from '../mocks';
+import { TranslocoService } from '../../transloco.service';
+
+import { loadLang } from './service-spec-utils';
+
+describe('translate in a reactive context', () => {
+  let service: TranslocoService;
+
+  beforeEach(() => (service = createService()));
+
+  it(`GIVEN a computed that calls translate() without an explicit language
+      WHEN the active language changes
+      THEN the computed should re-run and return the new language's translation`, fakeAsync(() => {
+    loadLang(service);
+    loadLang(service, 'es');
+
+    const message = computed(() => service.translate('home'));
+    expect(message()).toEqual(mockLangs['en'].home);
+
+    service.setActiveLang('es');
+    expect(message()).toEqual(mockLangs['es'].home);
+  }));
+
+  it(`GIVEN a computed that calls translate() with an explicit language
+      WHEN the active language changes
+      THEN the computed should keep returning the requested language's translation`, fakeAsync(() => {
+    loadLang(service);
+    loadLang(service, 'es');
+
+    const message = computed(() => service.translate('home', {}, 'en'));
+    expect(message()).toEqual(mockLangs['en'].home);
+
+    service.setActiveLang('es');
+    expect(message()).toEqual(mockLangs['en'].home);
+  }));
+
+  it(`GIVEN a computed that calls translateObject() without an explicit language
+      WHEN the active language changes
+      THEN the computed should re-run and return the new language's translation`, fakeAsync(() => {
+    loadLang(service);
+    loadLang(service, 'es');
+
+    const nested = computed(() => service.translateObject('a.b'));
+    expect(nested()).toEqual((mockLangs['en'] as any).a.b);
+
+    service.setActiveLang('es');
+    expect(nested()).toEqual((mockLangs['es'] as any).a.b);
+  }));
+});

--- a/libs/transloco/src/lib/transloco.service.ts
+++ b/libs/transloco/src/lib/transloco.service.ts
@@ -352,11 +352,15 @@ export class TranslocoService {
    * translate<string[]>(['hello', 'key'])
    * translate('hello', { }, 'en')
    * translate('scope.someKey', { }, 'en')
+   *
+   * When no language is given, the active language is read from the
+   * `activeLang` signal, so calling this method inside a reactive context
+   * (e.g. a `computed`) re-runs it when the active language changes.
    */
   translate<T = string>(
     key: TranslateParams,
     params: HashMap = {},
-    lang = this.getActiveLang(),
+    lang = this.activeLang(),
   ): T {
     if (!key) return key as any;
 
@@ -473,7 +477,7 @@ export class TranslocoService {
   translateObject<T = any>(
     key: TranslateObjectParams,
     params: HashMap | null = {},
-    lang = this.getActiveLang(),
+    lang = this.activeLang(),
   ): T | T[] {
     if (isString(key) || Array.isArray(key)) {
       const { resolveLang, scope } = this.resolveLangAndScope(lang);


### PR DESCRIPTION
Closes #1013

## What

`translate()` and `translateObject()` now default their `lang` parameter to the existing `activeLang` **signal** instead of `getActiveLang()` (the internal BehaviorSubject read).

## Why

When either method is called without an explicit language inside a reactive context (a `computed`), the language read registered no signal dependency — so the computed memoized the translation, and a later `setActiveLang()` never invalidated it. This surfaces prominently with Angular Signal Forms, which evaluates validator `message` functions inside its internal validation computed and caches the resulting error object: validation messages stay in the boot-time language until the field's value changes (full reproduction in #1013).

With the `activeLang` signal as the default, the surrounding computed tracks the language and re-runs on a switch.

## Behavior notes

- Calls **with an explicit `lang`** are untouched.
- Calls **outside reactive contexts** behave exactly as before — a signal read is just a read (`toSignal(..., { requireSync: true })` always has a value).
- This deliberately does **not** make `translate()` react to translation *loads* — the sync API remains a snapshot, and `selectTranslate`/`translateSignal` remain the load-aware reactive APIs. It only fixes the language-tracking gap, which callers cannot work around when framework code owns the computed.

## Tests

`reactive-context.spec.ts`: a computed re-runs and re-translates on `setActiveLang()` for both `translate()` and `translateObject()`; a computed with an explicit language is unaffected. Full suite: 255/255 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Translations now update automatically in reactive Angular contexts when the active language changes.
  - Translation objects refresh correctly when the active language changes.
  - Explicitly requested languages continue to return their selected translations.

- **Tests**
  - Added coverage for reactive translation and nested translation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->